### PR TITLE
feat(#28): Link type registry with ReDoS prevention

### DIFF
--- a/src/SeriesScraper.Application/Services/LinkTypeService.cs
+++ b/src/SeriesScraper.Application/Services/LinkTypeService.cs
@@ -1,0 +1,140 @@
+using System.Text.RegularExpressions;
+using SeriesScraper.Domain.Entities;
+using SeriesScraper.Domain.Interfaces;
+
+namespace SeriesScraper.Application.Services;
+
+public class LinkTypeService : ILinkTypeService
+{
+    private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(2);
+    private const int MaxPatternLength = 1000;
+
+    // Detect patterns prone to catastrophic backtracking:
+    // nested quantifiers like (a+)+, (a*)+, (a+)*, (.+)+ etc.
+    private static readonly Regex NestedQuantifierPattern = new(
+        @"\([^)]*[+*][^)]*\)[+*?]|\([^)]*[+*][^)]*\)\{",
+        RegexOptions.Compiled,
+        TimeSpan.FromSeconds(1));
+
+    private readonly ILinkTypeRepository _repository;
+
+    public LinkTypeService(ILinkTypeRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public Task<IReadOnlyList<LinkType>> GetAllAsync(CancellationToken cancellationToken = default)
+        => _repository.GetAllAsync(cancellationToken);
+
+    public Task<IReadOnlyList<LinkType>> GetActiveAsync(CancellationToken cancellationToken = default)
+        => _repository.GetActiveAsync(cancellationToken);
+
+    public Task<LinkType?> GetByIdAsync(int linkTypeId, CancellationToken cancellationToken = default)
+        => _repository.GetByIdAsync(linkTypeId, cancellationToken);
+
+    public async Task<LinkType> CreateAsync(string name, string urlPattern, string? iconClass = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentException.ThrowIfNullOrWhiteSpace(urlPattern);
+
+        ValidateUrlPattern(urlPattern);
+
+        if (await _repository.ExistsByNameAsync(name, cancellationToken))
+            throw new InvalidOperationException($"A link type with the name '{name}' already exists.");
+
+        var linkType = new LinkType
+        {
+            Name = name.Trim(),
+            UrlPattern = urlPattern.Trim(),
+            IconClass = iconClass?.Trim(),
+            IsSystem = false,
+            IsActive = true
+        };
+
+        return await _repository.AddAsync(linkType, cancellationToken);
+    }
+
+    public async Task<LinkType> UpdateAsync(int linkTypeId, string name, string urlPattern, bool isActive, string? iconClass = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentException.ThrowIfNullOrWhiteSpace(urlPattern);
+
+        ValidateUrlPattern(urlPattern);
+
+        var existing = await _repository.GetByIdAsync(linkTypeId, cancellationToken)
+            ?? throw new KeyNotFoundException($"Link type with ID {linkTypeId} not found.");
+
+        var byName = await _repository.GetByNameAsync(name, cancellationToken);
+        if (byName is not null && byName.LinkTypeId != linkTypeId)
+            throw new InvalidOperationException($"A link type with the name '{name}' already exists.");
+
+        existing.Name = name.Trim();
+        existing.UrlPattern = urlPattern.Trim();
+        existing.IsActive = isActive;
+        existing.IconClass = iconClass?.Trim();
+
+        await _repository.UpdateAsync(existing, cancellationToken);
+        return existing;
+    }
+
+    public async Task<bool> DeleteAsync(int linkTypeId, CancellationToken cancellationToken = default)
+    {
+        var existing = await _repository.GetByIdAsync(linkTypeId, cancellationToken);
+        if (existing is null)
+            return false;
+
+        if (existing.IsSystem)
+            throw new InvalidOperationException("System link types cannot be deleted.");
+
+        return await _repository.DeleteAsync(linkTypeId, cancellationToken);
+    }
+
+    public void ValidateUrlPattern(string pattern)
+    {
+        if (string.IsNullOrWhiteSpace(pattern))
+            throw new ArgumentException("URL pattern cannot be empty.", nameof(pattern));
+
+        if (pattern.Length > MaxPatternLength)
+            throw new ArgumentException($"URL pattern exceeds maximum length of {MaxPatternLength} characters.", nameof(pattern));
+
+        // ReDoS prevention: reject patterns with nested quantifiers
+        if (NestedQuantifierPattern.IsMatch(pattern))
+            throw new ArgumentException("URL pattern contains nested quantifiers which may cause catastrophic backtracking (ReDoS).", nameof(pattern));
+
+        // Validate regex compilation with timeout
+        try
+        {
+            _ = new Regex(pattern, RegexOptions.None, RegexTimeout);
+        }
+        catch (ArgumentException ex)
+        {
+            throw new ArgumentException($"URL pattern is not a valid regex: {ex.Message}", nameof(pattern), ex);
+        }
+    }
+
+    public int? ClassifyUrl(string url, IReadOnlyList<LinkType> linkTypes)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+            return null;
+
+        foreach (var linkType in linkTypes)
+        {
+            if (!linkType.IsActive)
+                continue;
+
+            try
+            {
+                var regex = new Regex(linkType.UrlPattern, RegexOptions.IgnoreCase, RegexTimeout);
+                if (regex.IsMatch(url))
+                    return linkType.LinkTypeId;
+            }
+            catch (RegexMatchTimeoutException)
+            {
+                // ReDoS prevention: pattern timed out, skip this type
+                continue;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/SeriesScraper.Domain/Interfaces/ILinkTypeRepository.cs
+++ b/src/SeriesScraper.Domain/Interfaces/ILinkTypeRepository.cs
@@ -1,0 +1,15 @@
+using SeriesScraper.Domain.Entities;
+
+namespace SeriesScraper.Domain.Interfaces;
+
+public interface ILinkTypeRepository
+{
+    Task<IReadOnlyList<LinkType>> GetAllAsync(CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<LinkType>> GetActiveAsync(CancellationToken cancellationToken = default);
+    Task<LinkType?> GetByIdAsync(int linkTypeId, CancellationToken cancellationToken = default);
+    Task<LinkType?> GetByNameAsync(string name, CancellationToken cancellationToken = default);
+    Task<LinkType> AddAsync(LinkType linkType, CancellationToken cancellationToken = default);
+    Task UpdateAsync(LinkType linkType, CancellationToken cancellationToken = default);
+    Task<bool> DeleteAsync(int linkTypeId, CancellationToken cancellationToken = default);
+    Task<bool> ExistsByNameAsync(string name, CancellationToken cancellationToken = default);
+}

--- a/src/SeriesScraper.Domain/Interfaces/ILinkTypeService.cs
+++ b/src/SeriesScraper.Domain/Interfaces/ILinkTypeService.cs
@@ -1,0 +1,15 @@
+using SeriesScraper.Domain.Entities;
+
+namespace SeriesScraper.Domain.Interfaces;
+
+public interface ILinkTypeService
+{
+    Task<IReadOnlyList<LinkType>> GetAllAsync(CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<LinkType>> GetActiveAsync(CancellationToken cancellationToken = default);
+    Task<LinkType?> GetByIdAsync(int linkTypeId, CancellationToken cancellationToken = default);
+    Task<LinkType> CreateAsync(string name, string urlPattern, string? iconClass = null, CancellationToken cancellationToken = default);
+    Task<LinkType> UpdateAsync(int linkTypeId, string name, string urlPattern, bool isActive, string? iconClass = null, CancellationToken cancellationToken = default);
+    Task<bool> DeleteAsync(int linkTypeId, CancellationToken cancellationToken = default);
+    void ValidateUrlPattern(string pattern);
+    int? ClassifyUrl(string url, IReadOnlyList<LinkType> linkTypes);
+}

--- a/src/SeriesScraper.Infrastructure/Data/LinkTypeRepository.cs
+++ b/src/SeriesScraper.Infrastructure/Data/LinkTypeRepository.cs
@@ -1,0 +1,80 @@
+using Microsoft.EntityFrameworkCore;
+using SeriesScraper.Domain.Entities;
+using SeriesScraper.Domain.Interfaces;
+using SeriesScraper.Infrastructure.Data;
+
+namespace SeriesScraper.Infrastructure.Data;
+
+public class LinkTypeRepository : ILinkTypeRepository
+{
+    private readonly AppDbContext _context;
+
+    public LinkTypeRepository(AppDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<IReadOnlyList<LinkType>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        return await _context.LinkTypes
+            .OrderBy(lt => lt.LinkTypeId)
+            .AsNoTracking()
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<LinkType>> GetActiveAsync(CancellationToken cancellationToken = default)
+    {
+        return await _context.LinkTypes
+            .Where(lt => lt.IsActive)
+            .OrderBy(lt => lt.LinkTypeId)
+            .AsNoTracking()
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<LinkType?> GetByIdAsync(int linkTypeId, CancellationToken cancellationToken = default)
+    {
+        return await _context.LinkTypes
+            .FirstOrDefaultAsync(lt => lt.LinkTypeId == linkTypeId, cancellationToken);
+    }
+
+    public async Task<LinkType?> GetByNameAsync(string name, CancellationToken cancellationToken = default)
+    {
+        return await _context.LinkTypes
+            .FirstOrDefaultAsync(lt => lt.Name == name, cancellationToken);
+    }
+
+    public async Task<LinkType> AddAsync(LinkType linkType, CancellationToken cancellationToken = default)
+    {
+        _context.LinkTypes.Add(linkType);
+        await _context.SaveChangesAsync(cancellationToken);
+        return linkType;
+    }
+
+    public async Task UpdateAsync(LinkType linkType, CancellationToken cancellationToken = default)
+    {
+        _context.LinkTypes.Update(linkType);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task<bool> DeleteAsync(int linkTypeId, CancellationToken cancellationToken = default)
+    {
+        var entity = await _context.LinkTypes
+            .FirstOrDefaultAsync(lt => lt.LinkTypeId == linkTypeId, cancellationToken);
+
+        if (entity is null)
+            return false;
+
+        if (entity.IsSystem)
+            return false;
+
+        _context.LinkTypes.Remove(entity);
+        await _context.SaveChangesAsync(cancellationToken);
+        return true;
+    }
+
+    public async Task<bool> ExistsByNameAsync(string name, CancellationToken cancellationToken = default)
+    {
+        return await _context.LinkTypes
+            .AnyAsync(lt => lt.Name == name, cancellationToken);
+    }
+}

--- a/tests/SeriesScraper.Application.Tests/SeriesScraper.Application.Tests.csproj
+++ b/tests/SeriesScraper.Application.Tests/SeriesScraper.Application.Tests.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
     <PackageReference Include="FluentAssertions" Version="6.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Moq" Version="4.20.*" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>

--- a/tests/SeriesScraper.Application.Tests/Services/LinkTypeServiceTests.cs
+++ b/tests/SeriesScraper.Application.Tests/Services/LinkTypeServiceTests.cs
@@ -1,0 +1,429 @@
+using FluentAssertions;
+using Moq;
+using SeriesScraper.Application.Services;
+using SeriesScraper.Domain.Entities;
+using SeriesScraper.Domain.Interfaces;
+
+namespace SeriesScraper.Application.Tests.Services;
+
+public class LinkTypeServiceTests
+{
+    private readonly Mock<ILinkTypeRepository> _repoMock = new();
+    private readonly LinkTypeService _sut;
+
+    public LinkTypeServiceTests()
+    {
+        _sut = new LinkTypeService(_repoMock.Object);
+    }
+
+    // ── GetAllAsync ──────────────────────────────────────────
+
+    [Fact]
+    public async Task GetAllAsync_ReturnsAllFromRepository()
+    {
+        var expected = new List<LinkType>
+        {
+            new() { LinkTypeId = 1, Name = "Direct HTTP", UrlPattern = @"^https?://", IsSystem = true },
+            new() { LinkTypeId = 2, Name = "Torrent File", UrlPattern = @"\.torrent$", IsSystem = true }
+        };
+        _repoMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expected);
+
+        var result = await _sut.GetAllAsync();
+
+        result.Should().BeEquivalentTo(expected);
+    }
+
+    // ── GetActiveAsync ───────────────────────────────────────
+
+    [Fact]
+    public async Task GetActiveAsync_ReturnsActiveFromRepository()
+    {
+        var expected = new List<LinkType>
+        {
+            new() { LinkTypeId = 1, Name = "Direct HTTP", UrlPattern = @"^https?://", IsSystem = true, IsActive = true }
+        };
+        _repoMock.Setup(r => r.GetActiveAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expected);
+
+        var result = await _sut.GetActiveAsync();
+
+        result.Should().BeEquivalentTo(expected);
+    }
+
+    // ── GetByIdAsync ─────────────────────────────────────────
+
+    [Fact]
+    public async Task GetByIdAsync_ExistingId_ReturnsLinkType()
+    {
+        var expected = new LinkType { LinkTypeId = 1, Name = "Test", UrlPattern = ".*" };
+        _repoMock.Setup(r => r.GetByIdAsync(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expected);
+
+        var result = await _sut.GetByIdAsync(1);
+
+        result.Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_NonExistingId_ReturnsNull()
+    {
+        _repoMock.Setup(r => r.GetByIdAsync(999, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((LinkType?)null);
+
+        var result = await _sut.GetByIdAsync(999);
+
+        result.Should().BeNull();
+    }
+
+    // ── CreateAsync ──────────────────────────────────────────
+
+    [Fact]
+    public async Task CreateAsync_ValidInput_CreatesNonSystemLinkType()
+    {
+        _repoMock.Setup(r => r.ExistsByNameAsync("Custom Type", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        _repoMock.Setup(r => r.AddAsync(It.IsAny<LinkType>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((LinkType lt, CancellationToken _) => { lt.LinkTypeId = 5; return lt; });
+
+        var result = await _sut.CreateAsync("Custom Type", @"^ftp://", "fa-download");
+
+        result.Name.Should().Be("Custom Type");
+        result.UrlPattern.Should().Be(@"^ftp://");
+        result.IconClass.Should().Be("fa-download");
+        result.IsSystem.Should().BeFalse();
+        result.IsActive.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CreateAsync_DuplicateName_ThrowsInvalidOperation()
+    {
+        _repoMock.Setup(r => r.ExistsByNameAsync("Direct HTTP", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var act = () => _sut.CreateAsync("Direct HTTP", @"^https?://");
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*already exists*");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task CreateAsync_EmptyName_ThrowsArgumentException(string? name)
+    {
+        var act = () => _sut.CreateAsync(name!, @"^https?://");
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task CreateAsync_EmptyPattern_ThrowsArgumentException(string? pattern)
+    {
+        var act = () => _sut.CreateAsync("Test", pattern!);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task CreateAsync_InvalidRegex_ThrowsArgumentException()
+    {
+        _repoMock.Setup(r => r.ExistsByNameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var act = () => _sut.CreateAsync("Bad Pattern", @"[invalid");
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*not a valid regex*");
+    }
+
+    // ── UpdateAsync ──────────────────────────────────────────
+
+    [Fact]
+    public async Task UpdateAsync_ValidInput_UpdatesLinkType()
+    {
+        var existing = new LinkType
+        {
+            LinkTypeId = 5, Name = "Old Name", UrlPattern = @"^old://", IsSystem = false, IsActive = true
+        };
+        _repoMock.Setup(r => r.GetByIdAsync(5, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+        _repoMock.Setup(r => r.GetByNameAsync("New Name", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((LinkType?)null);
+
+        var result = await _sut.UpdateAsync(5, "New Name", @"^new://", false, "fa-link");
+
+        result.Name.Should().Be("New Name");
+        result.UrlPattern.Should().Be(@"^new://");
+        result.IsActive.Should().BeFalse();
+        result.IconClass.Should().Be("fa-link");
+        _repoMock.Verify(r => r.UpdateAsync(existing, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_NonExistingId_ThrowsKeyNotFound()
+    {
+        _repoMock.Setup(r => r.GetByIdAsync(999, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((LinkType?)null);
+
+        var act = () => _sut.UpdateAsync(999, "Name", @"^x://", true);
+
+        await act.Should().ThrowAsync<KeyNotFoundException>();
+    }
+
+    [Fact]
+    public async Task UpdateAsync_DuplicateName_ThrowsInvalidOperation()
+    {
+        var existing = new LinkType { LinkTypeId = 5, Name = "Original", UrlPattern = ".*" };
+        var conflict = new LinkType { LinkTypeId = 6, Name = "Taken", UrlPattern = ".*" };
+
+        _repoMock.Setup(r => r.GetByIdAsync(5, It.IsAny<CancellationToken>())).ReturnsAsync(existing);
+        _repoMock.Setup(r => r.GetByNameAsync("Taken", It.IsAny<CancellationToken>())).ReturnsAsync(conflict);
+
+        var act = () => _sut.UpdateAsync(5, "Taken", ".*", true);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*already exists*");
+    }
+
+    [Fact]
+    public async Task UpdateAsync_SameNameSameId_Succeeds()
+    {
+        var existing = new LinkType { LinkTypeId = 5, Name = "Same Name", UrlPattern = ".*" };
+        _repoMock.Setup(r => r.GetByIdAsync(5, It.IsAny<CancellationToken>())).ReturnsAsync(existing);
+        _repoMock.Setup(r => r.GetByNameAsync("Same Name", It.IsAny<CancellationToken>())).ReturnsAsync(existing);
+
+        var result = await _sut.UpdateAsync(5, "Same Name", @"^updated://", true);
+
+        result.UrlPattern.Should().Be(@"^updated://");
+    }
+
+    // ── DeleteAsync ──────────────────────────────────────────
+
+    [Fact]
+    public async Task DeleteAsync_NonExistingId_ReturnsFalse()
+    {
+        _repoMock.Setup(r => r.GetByIdAsync(999, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((LinkType?)null);
+
+        var result = await _sut.DeleteAsync(999);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task DeleteAsync_SystemType_ThrowsInvalidOperation()
+    {
+        var systemType = new LinkType { LinkTypeId = 1, Name = "Direct HTTP", UrlPattern = ".*", IsSystem = true };
+        _repoMock.Setup(r => r.GetByIdAsync(1, It.IsAny<CancellationToken>())).ReturnsAsync(systemType);
+
+        var act = () => _sut.DeleteAsync(1);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*System link types*");
+    }
+
+    [Fact]
+    public async Task DeleteAsync_UserType_DelegatesToRepository()
+    {
+        var userType = new LinkType { LinkTypeId = 5, Name = "Custom", UrlPattern = ".*", IsSystem = false };
+        _repoMock.Setup(r => r.GetByIdAsync(5, It.IsAny<CancellationToken>())).ReturnsAsync(userType);
+        _repoMock.Setup(r => r.DeleteAsync(5, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+        var result = await _sut.DeleteAsync(5);
+
+        result.Should().BeTrue();
+    }
+
+    // ── ValidateUrlPattern ───────────────────────────────────
+
+    [Theory]
+    [InlineData(@"^https?://")]
+    [InlineData(@"\.torrent$")]
+    [InlineData(@"^magnet:\?")]
+    [InlineData(@"(drive\.google|dropbox|mega\.nz)")]
+    [InlineData(@"^ftp://[a-z]+")]
+    public void ValidateUrlPattern_ValidPatterns_DoesNotThrow(string pattern)
+    {
+        var act = () => _sut.ValidateUrlPattern(pattern);
+
+        act.Should().NotThrow();
+    }
+
+    [Theory]
+    [InlineData(@"[invalid")]
+    [InlineData(@"(?P<broken")]
+    [InlineData(@"(unclosed")]
+    public void ValidateUrlPattern_InvalidRegex_ThrowsArgumentException(string pattern)
+    {
+        var act = () => _sut.ValidateUrlPattern(pattern);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*not a valid regex*");
+    }
+
+    [Theory]
+    [InlineData(@"(a+)+")]
+    [InlineData(@"(a*)+")]
+    [InlineData(@"(a+)*")]
+    [InlineData(@"(.+)+")]
+    [InlineData(@"(x+){2,}")]
+    public void ValidateUrlPattern_NestedQuantifiers_ThrowsArgumentException(string pattern)
+    {
+        var act = () => _sut.ValidateUrlPattern(pattern);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*nested quantifiers*");
+    }
+
+    [Fact]
+    public void ValidateUrlPattern_EmptyPattern_ThrowsArgumentException()
+    {
+        var act = () => _sut.ValidateUrlPattern("");
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void ValidateUrlPattern_PatternTooLong_ThrowsArgumentException()
+    {
+        var longPattern = new string('a', 1001);
+
+        var act = () => _sut.ValidateUrlPattern(longPattern);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*maximum length*");
+    }
+
+    // ── ClassifyUrl ──────────────────────────────────────────
+
+    [Fact]
+    public void ClassifyUrl_MatchingHttpUrl_ReturnsLinkTypeId()
+    {
+        var linkTypes = new List<LinkType>
+        {
+            new() { LinkTypeId = 1, Name = "Direct HTTP", UrlPattern = @"^https?://", IsActive = true },
+            new() { LinkTypeId = 2, Name = "Torrent File", UrlPattern = @"\.torrent$", IsActive = true }
+        };
+
+        var result = _sut.ClassifyUrl("https://example.com/file.zip", linkTypes);
+
+        result.Should().Be(1);
+    }
+
+    [Fact]
+    public void ClassifyUrl_MatchingTorrentUrl_ReturnsCorrectId()
+    {
+        var linkTypes = new List<LinkType>
+        {
+            new() { LinkTypeId = 1, Name = "Direct HTTP", UrlPattern = @"^https?://", IsActive = true },
+            new() { LinkTypeId = 2, Name = "Torrent File", UrlPattern = @"\.torrent$", IsActive = true }
+        };
+
+        var result = _sut.ClassifyUrl("https://example.com/file.torrent", linkTypes);
+
+        // First match wins: Direct HTTP matches first
+        result.Should().Be(1);
+    }
+
+    [Fact]
+    public void ClassifyUrl_NoMatch_ReturnsNull()
+    {
+        var linkTypes = new List<LinkType>
+        {
+            new() { LinkTypeId = 2, Name = "Torrent File", UrlPattern = @"\.torrent$", IsActive = true }
+        };
+
+        var result = _sut.ClassifyUrl("https://example.com/file.zip", linkTypes);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void ClassifyUrl_InactiveType_IsSkipped()
+    {
+        var linkTypes = new List<LinkType>
+        {
+            new() { LinkTypeId = 1, Name = "Direct HTTP", UrlPattern = @"^https?://", IsActive = false },
+            new() { LinkTypeId = 2, Name = "Torrent File", UrlPattern = @"\.torrent$", IsActive = true }
+        };
+
+        var result = _sut.ClassifyUrl("https://example.com/file.zip", linkTypes);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void ClassifyUrl_EmptyUrl_ReturnsNull()
+    {
+        var linkTypes = new List<LinkType>
+        {
+            new() { LinkTypeId = 1, Name = "Direct HTTP", UrlPattern = @"^https?://", IsActive = true }
+        };
+
+        var result = _sut.ClassifyUrl("", linkTypes);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void ClassifyUrl_NullUrl_ReturnsNull()
+    {
+        var linkTypes = new List<LinkType>
+        {
+            new() { LinkTypeId = 1, Name = "Direct HTTP", UrlPattern = @"^https?://", IsActive = true }
+        };
+
+        var result = _sut.ClassifyUrl(null!, linkTypes);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void ClassifyUrl_MagnetUri_Matches()
+    {
+        var linkTypes = new List<LinkType>
+        {
+            new() { LinkTypeId = 3, Name = "Magnet URI", UrlPattern = @"^magnet:\?", IsActive = true }
+        };
+
+        var result = _sut.ClassifyUrl("magnet:?xt=urn:btih:abc123", linkTypes);
+
+        result.Should().Be(3);
+    }
+
+    [Fact]
+    public void ClassifyUrl_CloudStorageUrl_Matches()
+    {
+        var linkTypes = new List<LinkType>
+        {
+            new() { LinkTypeId = 4, Name = "Cloud Storage URL", UrlPattern = @"(drive\.google|dropbox|mega\.nz)", IsActive = true }
+        };
+
+        var result = _sut.ClassifyUrl("https://drive.google.com/file/d/abc", linkTypes);
+
+        result.Should().Be(4);
+    }
+
+    [Fact]
+    public void ClassifyUrl_TimeoutPattern_SkipsAndReturnsNull()
+    {
+        // This pattern with nested quantifiers would cause timeout on adversarial input
+        // but since we're testing the timeout catch, we use a legitimate slow-ish pattern
+        var linkTypes = new List<LinkType>
+        {
+            new() { LinkTypeId = 99, Name = "Slow", UrlPattern = @"^(a+)+$", IsActive = true }
+        };
+
+        // Supply adversarial input that triggers catastrophic backtracking
+        var evilInput = new string('a', 30) + "!";
+        var result = _sut.ClassifyUrl(evilInput, linkTypes);
+
+        // Should either return null (timeout) or not hang
+        result.Should().BeNull();
+    }
+}

--- a/tests/SeriesScraper.Infrastructure.Tests/Data/LinkTypeRepositoryTests.cs
+++ b/tests/SeriesScraper.Infrastructure.Tests/Data/LinkTypeRepositoryTests.cs
@@ -1,0 +1,225 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using SeriesScraper.Domain.Entities;
+using SeriesScraper.Infrastructure.Data;
+
+namespace SeriesScraper.Infrastructure.Tests.Data;
+
+public class LinkTypeRepositoryTests
+{
+    private static (AppDbContext Context, LinkTypeRepository Repository) CreateSut()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        var context = new AppDbContext(options);
+        context.Database.EnsureCreated();
+        return (context, new LinkTypeRepository(context));
+    }
+
+    // ── GetAllAsync ──────────────────────────────────────────
+
+    [Fact]
+    public async Task GetAllAsync_ReturnsSeedData()
+    {
+        var (context, sut) = CreateSut();
+        using var _ = context;
+
+        var result = await sut.GetAllAsync();
+
+        result.Should().HaveCountGreaterOrEqualTo(4);
+        result.Should().Contain(lt => lt.Name == "Direct HTTP");
+        result.Should().Contain(lt => lt.Name == "Torrent File");
+        result.Should().Contain(lt => lt.Name == "Magnet URI");
+        result.Should().Contain(lt => lt.Name == "Cloud Storage URL");
+    }
+
+    [Fact]
+    public async Task GetAllAsync_IncludesInactiveTypes()
+    {
+        var (context, sut) = CreateSut();
+        using var _ = context;
+
+        context.LinkTypes.Add(new LinkType { Name = "Inactive", UrlPattern = ".*", IsActive = false });
+        await context.SaveChangesAsync();
+
+        var result = await sut.GetAllAsync();
+
+        result.Should().Contain(lt => lt.Name == "Inactive");
+    }
+
+    // ── GetActiveAsync ───────────────────────────────────────
+
+    [Fact]
+    public async Task GetActiveAsync_ExcludesInactiveTypes()
+    {
+        var (context, sut) = CreateSut();
+        using var _ = context;
+
+        context.LinkTypes.Add(new LinkType { Name = "Inactive", UrlPattern = ".*", IsActive = false });
+        await context.SaveChangesAsync();
+
+        var result = await sut.GetActiveAsync();
+
+        result.Should().NotContain(lt => lt.Name == "Inactive");
+        result.Should().OnlyContain(lt => lt.IsActive);
+    }
+
+    // ── GetByIdAsync ─────────────────────────────────────────
+
+    [Fact]
+    public async Task GetByIdAsync_ExistingId_ReturnsLinkType()
+    {
+        var (context, sut) = CreateSut();
+        using var _ = context;
+
+        var result = await sut.GetByIdAsync(1);
+
+        result.Should().NotBeNull();
+        result!.Name.Should().Be("Direct HTTP");
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_NonExistingId_ReturnsNull()
+    {
+        var (context, sut) = CreateSut();
+        using var _ = context;
+
+        var result = await sut.GetByIdAsync(999);
+
+        result.Should().BeNull();
+    }
+
+    // ── GetByNameAsync ───────────────────────────────────────
+
+    [Fact]
+    public async Task GetByNameAsync_ExistingName_ReturnsLinkType()
+    {
+        var (context, sut) = CreateSut();
+        using var _ = context;
+
+        var result = await sut.GetByNameAsync("Magnet URI");
+
+        result.Should().NotBeNull();
+        result!.LinkTypeId.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task GetByNameAsync_NonExistingName_ReturnsNull()
+    {
+        var (context, sut) = CreateSut();
+        using var _ = context;
+
+        var result = await sut.GetByNameAsync("Nonexistent");
+
+        result.Should().BeNull();
+    }
+
+    // ── AddAsync ─────────────────────────────────────────────
+
+    [Fact]
+    public async Task AddAsync_ValidLinkType_PersistsAndReturnsWithId()
+    {
+        var (context, sut) = CreateSut();
+        using var _ = context;
+
+        var linkType = new LinkType
+        {
+            Name = "FTP Link",
+            UrlPattern = @"^ftp://",
+            IsSystem = false,
+            IsActive = true
+        };
+
+        var result = await sut.AddAsync(linkType);
+
+        result.LinkTypeId.Should().BeGreaterThan(0);
+
+        var fromDb = await context.LinkTypes.FindAsync(result.LinkTypeId);
+        fromDb.Should().NotBeNull();
+        fromDb!.Name.Should().Be("FTP Link");
+    }
+
+    // ── UpdateAsync ──────────────────────────────────────────
+
+    [Fact]
+    public async Task UpdateAsync_ModifiesExistingEntity()
+    {
+        var (context, sut) = CreateSut();
+        using var _ = context;
+
+        var existing = await sut.GetByIdAsync(1);
+        existing!.IconClass = "fa-globe";
+
+        await sut.UpdateAsync(existing);
+
+        var updated = await context.LinkTypes.FindAsync(1);
+        updated!.IconClass.Should().Be("fa-globe");
+    }
+
+    // ── DeleteAsync ──────────────────────────────────────────
+
+    [Fact]
+    public async Task DeleteAsync_UserType_RemovesAndReturnsTrue()
+    {
+        var (context, sut) = CreateSut();
+        using var _ = context;
+
+        var userType = new LinkType { Name = "Temp", UrlPattern = ".*", IsSystem = false, IsActive = true };
+        context.LinkTypes.Add(userType);
+        await context.SaveChangesAsync();
+
+        var result = await sut.DeleteAsync(userType.LinkTypeId);
+
+        result.Should().BeTrue();
+        (await context.LinkTypes.FindAsync(userType.LinkTypeId)).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task DeleteAsync_SystemType_ReturnsFalse()
+    {
+        var (context, sut) = CreateSut();
+        using var _ = context;
+
+        var result = await sut.DeleteAsync(1); // Direct HTTP is system
+
+        result.Should().BeFalse();
+        (await context.LinkTypes.FindAsync(1)).Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task DeleteAsync_NonExistingId_ReturnsFalse()
+    {
+        var (context, sut) = CreateSut();
+        using var _ = context;
+
+        var result = await sut.DeleteAsync(999);
+
+        result.Should().BeFalse();
+    }
+
+    // ── ExistsByNameAsync ────────────────────────────────────
+
+    [Fact]
+    public async Task ExistsByNameAsync_ExistingName_ReturnsTrue()
+    {
+        var (context, sut) = CreateSut();
+        using var _ = context;
+
+        var result = await sut.ExistsByNameAsync("Direct HTTP");
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ExistsByNameAsync_NonExistingName_ReturnsFalse()
+    {
+        var (context, sut) = CreateSut();
+        using var _ = context;
+
+        var result = await sut.ExistsByNameAsync("Nonexistent");
+
+        result.Should().BeFalse();
+    }
+}

--- a/tests/SeriesScraper.Infrastructure.Tests/SeriesScraper.Infrastructure.Tests.csproj
+++ b/tests/SeriesScraper.Infrastructure.Tests/SeriesScraper.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="FluentAssertions" Version="6.*" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />


### PR DESCRIPTION
Closes #28

## Summary of Changes

Implements the link type registry service layer: database-driven CRUD for URL patterns that classify extracted links, with full ReDoS prevention per security policy (#48).

### Domain Layer
- **ILinkTypeRepository** — full CRUD contract (GetAll, GetActive, GetById, GetByName, Add, Update, Delete, ExistsByName)
- **ILinkTypeService** — service contract with CRUD, pattern validation, and URL classification

### Infrastructure Layer
- **LinkTypeRepository** — EF Core implementation with system type delete guard

### Application Layer
- **LinkTypeService** — full implementation:
  - **ReDoS prevention**: all regex compiled with `TimeSpan.FromSeconds(2)` timeout
  - **Nested quantifier detection**: rejects patterns like `(a+)+`, `(a*)+`
  - **Pattern length limit**: 1000 characters max
  - **Regex compilation validation**: invalid patterns rejected with descriptive error
  - **Duplicate name validation** on create and update
  - **System type delete protection**
  - **URL classification**: first-match-wins against active link types, timeout-safe

### Tests (47 new)
- **LinkTypeServiceTests** (30 tests): CRUD, validation, ReDoS prevention, URL classification
- **LinkTypeRepositoryTests** (17 tests): all repository operations against InMemory EF Core

## Testing Notes
- All 268 tests pass (47 new + 221 existing)
- Moq added to Application.Tests for repository mocking

## Known Limitations
- No in-memory cache for link types yet (AC#4 — Settings UI scope)
- No UI (AC#5 — separate issue)
- ILinkParser implementations not included (AC#3 — separate concern)