### PR TITLE
feat(#26): Quality extraction and ranking engine

### DIFF
--- a/src/SeriesScraper.Application/Services/QualityExtractor.cs
+++ b/src/SeriesScraper.Application/Services/QualityExtractor.cs
@@ -1,0 +1,251 @@
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
+using SeriesScraper.Domain.Entities;
+using SeriesScraper.Domain.Enums;
+using SeriesScraper.Domain.Interfaces;
+using SeriesScraper.Domain.ValueObjects;
+
+namespace SeriesScraper.Application.Services;
+
+/// <summary>
+/// Extracts quality information from forum post text by scanning for known tokens,
+/// evaluating learned regex patterns, and proposing new patterns for learning.
+/// </summary>
+public class QualityExtractor : IQualityExtractor
+{
+    public const string AlgorithmVersion = "1.0";
+
+    private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(2);
+
+    /// <summary>
+    /// Heuristic patterns used to discover potential quality tokens not yet in the database.
+    /// Each pattern maps to a default derived rank and polarity.
+    /// </summary>
+    private static readonly IReadOnlyList<(Regex Pattern, int DefaultRank, TokenPolarity Polarity)> DiscoveryPatterns =
+    [
+        (new Regex(@"\b(\d{3,4}p)\b", RegexOptions.IgnoreCase | RegexOptions.Compiled, RegexTimeout), 50, TokenPolarity.Positive),
+        (new Regex(@"\b(x\d{3})\b", RegexOptions.IgnoreCase | RegexOptions.Compiled, RegexTimeout), 50, TokenPolarity.Positive),
+        (new Regex(@"\b(H\.?\d{3})\b", RegexOptions.IgnoreCase | RegexOptions.Compiled, RegexTimeout), 50, TokenPolarity.Positive),
+        (new Regex(@"\b(DTS[-\s]?HD)\b", RegexOptions.IgnoreCase | RegexOptions.Compiled, RegexTimeout), 50, TokenPolarity.Positive),
+        (new Regex(@"\b(Atmos)\b", RegexOptions.IgnoreCase | RegexOptions.Compiled, RegexTimeout), 50, TokenPolarity.Positive),
+        (new Regex(@"\b(Remux)\b", RegexOptions.IgnoreCase | RegexOptions.Compiled, RegexTimeout), 50, TokenPolarity.Positive),
+    ];
+
+    private readonly IQualityPatternService _patternService;
+    private readonly ILogger<QualityExtractor> _logger;
+
+    public QualityExtractor(IQualityPatternService patternService, ILogger<QualityExtractor> logger)
+    {
+        _patternService = patternService ?? throw new ArgumentNullException(nameof(patternService));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<QualityRank> ExtractAsync(string postText, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(postText))
+            return QualityRank.None;
+
+        var activeTokens = await _patternService.GetActiveTokensAsync(ct);
+        var activePatterns = await _patternService.GetActivePatternsAsync(ct);
+
+        var matches = new List<QualityMatch>();
+
+        // AC#1: Evaluate all active QualityTokens (case-insensitive word boundary match)
+        EvaluateTokens(postText, activeTokens, matches);
+
+        // AC#1: Evaluate all active QualityLearnedPatterns (regex match)
+        EvaluatePatterns(postText, activePatterns, matches);
+
+        // AC#3: Increment hit_count on matched patterns
+        await RecordPatternHitsAsync(matches, ct);
+
+        // AC#4: Discover and record new patterns from the post text
+        await DiscoverNewPatternsAsync(postText, activeTokens, activePatterns, ct);
+
+        if (matches.Count == 0)
+            return QualityRank.None;
+
+        // AC#2: Select best match — negative polarity downranked below any positive
+        return RankMatches(matches);
+    }
+
+    private void EvaluateTokens(string postText, IReadOnlyList<QualityToken> tokens, List<QualityMatch> matches)
+    {
+        foreach (var token in tokens)
+        {
+            if (ContainsToken(postText, token.TokenText))
+            {
+                matches.Add(new QualityMatch
+                {
+                    MatchedText = token.TokenText,
+                    Rank = token.QualityRank,
+                    Polarity = token.Polarity,
+                    Source = MatchSource.Token,
+                    PatternId = null
+                });
+            }
+        }
+    }
+
+    private void EvaluatePatterns(string postText, IReadOnlyList<QualityLearnedPattern> patterns, List<QualityMatch> matches)
+    {
+        foreach (var pattern in patterns)
+        {
+            // AC#5: Compile with timeout, catch RegexMatchTimeoutException
+            if (TryRegexMatch(postText, pattern.PatternRegex, out var matchedText))
+            {
+                matches.Add(new QualityMatch
+                {
+                    MatchedText = matchedText!,
+                    Rank = pattern.DerivedRank,
+                    Polarity = pattern.Polarity,
+                    Source = MatchSource.Pattern,
+                    PatternId = pattern.PatternId
+                });
+            }
+        }
+    }
+
+    private bool TryRegexMatch(string text, string pattern, out string? matchedText)
+    {
+        matchedText = null;
+        try
+        {
+            var regex = new Regex(pattern, RegexOptions.IgnoreCase, RegexTimeout);
+            var match = regex.Match(text);
+            if (match.Success)
+            {
+                matchedText = match.Value;
+                return true;
+            }
+            return false;
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            // AC#5: Log at WARN level with pattern text, treat as no-match
+            _logger.LogWarning("Regex pattern timed out after {Timeout}s: {Pattern}", RegexTimeout.TotalSeconds, pattern);
+            return false;
+        }
+    }
+
+    private async Task RecordPatternHitsAsync(List<QualityMatch> matches, CancellationToken ct)
+    {
+        // AC#3: Increment hit_count via single update statement (handled by repository)
+        foreach (var match in matches.Where(m => m.Source == MatchSource.Pattern && m.PatternId.HasValue))
+        {
+            await _patternService.RecordPatternHitAsync(match.PatternId!.Value, ct);
+        }
+    }
+
+    private async Task DiscoverNewPatternsAsync(
+        string postText,
+        IReadOnlyList<QualityToken> knownTokens,
+        IReadOnlyList<QualityLearnedPattern> knownPatterns,
+        CancellationToken ct)
+    {
+        // AC#4: Find potential quality tokens not in the database
+        var knownTokenTexts = new HashSet<string>(
+            knownTokens.Select(t => t.TokenText),
+            StringComparer.OrdinalIgnoreCase);
+
+        var knownPatternTexts = new HashSet<string>(
+            knownPatterns.Select(p => p.PatternRegex),
+            StringComparer.OrdinalIgnoreCase);
+
+        foreach (var (discoveryPattern, defaultRank, polarity) in DiscoveryPatterns)
+        {
+            MatchCollection regexMatches;
+            try
+            {
+                regexMatches = discoveryPattern.Matches(postText);
+            }
+            catch (RegexMatchTimeoutException)
+            {
+                _logger.LogWarning("Discovery pattern timed out: {Pattern}", discoveryPattern.ToString());
+                continue;
+            }
+
+            foreach (Match regexMatch in regexMatches)
+            {
+                var observed = regexMatch.Value;
+                if (knownTokenTexts.Contains(observed))
+                    continue;
+
+                // Build the pattern regex for the discovered token
+                var newPatternRegex = $@"\b{Regex.Escape(observed)}\b";
+                if (knownPatternTexts.Contains(newPatternRegex))
+                    continue;
+
+                // AC#4: Record as new learned pattern
+                var newPattern = await _patternService.AddLearnedPatternAsync(
+                    newPatternRegex, defaultRank, polarity, AlgorithmVersion, ct);
+
+                // Immediately record initial hit
+                await _patternService.RecordPatternHitAsync(newPattern.PatternId, ct);
+
+                // Track so we don't add duplicates within the same post
+                knownPatternTexts.Add(newPatternRegex);
+            }
+        }
+    }
+
+    private static QualityRank RankMatches(List<QualityMatch> matches)
+    {
+        var positiveMatches = matches.Where(m => m.Polarity == TokenPolarity.Positive).ToList();
+        var negativeMatches = matches.Where(m => m.Polarity == TokenPolarity.Negative).ToList();
+
+        QualityMatch bestMatch;
+
+        // AC#2: If any positive match exists, negative polarity is downranked below all positive
+        if (positiveMatches.Count > 0)
+        {
+            bestMatch = positiveMatches.OrderByDescending(m => m.Rank).First();
+        }
+        else
+        {
+            bestMatch = negativeMatches.OrderByDescending(m => m.Rank).First();
+        }
+
+        var allMatchedTokens = matches.Select(m => m.MatchedText).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+
+        // Confidence: scales with match count, approaches 1.0 asymptotically
+        var confidence = allMatchedTokens.Count / (allMatchedTokens.Count + 1.0);
+
+        return new QualityRank
+        {
+            Score = bestMatch.Rank,
+            MatchedTokens = allMatchedTokens,
+            Confidence = Math.Round(confidence, 4),
+            BestMatchPolarity = bestMatch.Polarity
+        };
+    }
+
+    private static bool ContainsToken(string text, string token)
+    {
+        // Case-insensitive word boundary match using IndexOf for performance
+        var index = text.IndexOf(token, StringComparison.OrdinalIgnoreCase);
+        while (index >= 0)
+        {
+            var before = index == 0 || !char.IsLetterOrDigit(text[index - 1]);
+            var afterPos = index + token.Length;
+            var after = afterPos >= text.Length || !char.IsLetterOrDigit(text[afterPos]);
+
+            if (before && after)
+                return true;
+
+            index = text.IndexOf(token, index + 1, StringComparison.OrdinalIgnoreCase);
+        }
+        return false;
+    }
+
+    private enum MatchSource { Token, Pattern }
+
+    private sealed class QualityMatch
+    {
+        public required string MatchedText { get; init; }
+        public required int Rank { get; init; }
+        public required TokenPolarity Polarity { get; init; }
+        public required MatchSource Source { get; init; }
+        public int? PatternId { get; init; }
+    }
+}

--- a/src/SeriesScraper.Domain/Interfaces/IQualityExtractor.cs
+++ b/src/SeriesScraper.Domain/Interfaces/IQualityExtractor.cs
@@ -1,0 +1,20 @@
+using SeriesScraper.Domain.ValueObjects;
+
+namespace SeriesScraper.Domain.Interfaces;
+
+/// <summary>
+/// Extracts quality information from forum post text by evaluating
+/// active quality tokens and learned patterns.
+/// </summary>
+public interface IQualityExtractor
+{
+    /// <summary>
+    /// Scans the post text for quality tokens and learned regex patterns,
+    /// selects the best match by rank (with negative polarity downranked),
+    /// increments hit counts on matched patterns, and records newly discovered patterns.
+    /// </summary>
+    /// <param name="postText">The plain-text content of a forum post.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A <see cref="QualityRank"/> representing the extraction result.</returns>
+    Task<QualityRank> ExtractAsync(string postText, CancellationToken ct = default);
+}

--- a/src/SeriesScraper.Domain/ValueObjects/QualityRank.cs
+++ b/src/SeriesScraper.Domain/ValueObjects/QualityRank.cs
@@ -1,0 +1,44 @@
+using SeriesScraper.Domain.Enums;
+
+namespace SeriesScraper.Domain.ValueObjects;
+
+/// <summary>
+/// Result of quality extraction from a forum post.
+/// Contains the overall quality score, all matched tokens, and a confidence rating.
+/// </summary>
+public sealed record QualityRank
+{
+    /// <summary>
+    /// The overall quality score (highest quality_rank among matches, adjusted for polarity).
+    /// Zero when no quality indicators are found.
+    /// </summary>
+    public int Score { get; init; }
+
+    /// <summary>
+    /// All quality tokens/patterns that matched in the post text.
+    /// </summary>
+    public IReadOnlyList<string> MatchedTokens { get; init; } = [];
+
+    /// <summary>
+    /// Confidence in the extraction result (0.0–1.0).
+    /// Higher values indicate more matching evidence.
+    /// </summary>
+    public double Confidence { get; init; }
+
+    /// <summary>
+    /// The polarity of the best (winning) match.
+    /// Null when no matches are found.
+    /// </summary>
+    public TokenPolarity? BestMatchPolarity { get; init; }
+
+    /// <summary>
+    /// Creates a QualityRank representing no quality information found.
+    /// </summary>
+    public static QualityRank None => new()
+    {
+        Score = 0,
+        MatchedTokens = [],
+        Confidence = 0.0,
+        BestMatchPolarity = null
+    };
+}

--- a/tests/SeriesScraper.Application.Tests/Services/QualityExtractorTests.cs
+++ b/tests/SeriesScraper.Application.Tests/Services/QualityExtractorTests.cs
@@ -1,0 +1,564 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using SeriesScraper.Application.Services;
+using SeriesScraper.Domain.Entities;
+using SeriesScraper.Domain.Enums;
+using SeriesScraper.Domain.Interfaces;
+using SeriesScraper.Domain.ValueObjects;
+
+namespace SeriesScraper.Application.Tests.Services;
+
+public class QualityExtractorTests
+{
+    private readonly Mock<IQualityPatternService> _patternServiceMock = new();
+    private readonly Mock<ILogger<QualityExtractor>> _loggerMock = new();
+    private readonly QualityExtractor _sut;
+
+    public QualityExtractorTests()
+    {
+        _sut = new QualityExtractor(_patternServiceMock.Object, _loggerMock.Object);
+    }
+
+    // ── Constructor ────────────────────────────────────────────────
+
+    [Fact]
+    public void Constructor_NullPatternService_ThrowsArgumentNullException()
+    {
+        var act = () => new QualityExtractor(null!, _loggerMock.Object);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("patternService");
+    }
+
+    [Fact]
+    public void Constructor_NullLogger_ThrowsArgumentNullException()
+    {
+        var act = () => new QualityExtractor(_patternServiceMock.Object, null!);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("logger");
+    }
+
+    // ── Empty/null input ───────────────────────────────────────────
+
+    [Fact]
+    public async Task ExtractAsync_NullText_ReturnsNone()
+    {
+        var result = await _sut.ExtractAsync(null!);
+        result.Should().Be(QualityRank.None);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_EmptyText_ReturnsNone()
+    {
+        var result = await _sut.ExtractAsync("");
+        result.Should().Be(QualityRank.None);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_WhitespaceText_ReturnsNone()
+    {
+        var result = await _sut.ExtractAsync("   ");
+        result.Should().Be(QualityRank.None);
+    }
+
+    // ── AC#1: Token matching ───────────────────────────────────────
+
+    [Fact]
+    public async Task ExtractAsync_KnownPositiveToken_ReturnsMatchWithCorrectScore()
+    {
+        // AC#6: Known positive match
+        SetupTokensAndPatterns(
+            tokens: [new() { TokenId = 1, TokenText = "1080p", QualityRank = 80, Polarity = TokenPolarity.Positive, IsActive = true }],
+            patterns: []);
+
+        var result = await _sut.ExtractAsync("Download Movie.Name.1080p.BluRay.x264");
+
+        result.Score.Should().Be(80);
+        result.MatchedTokens.Should().Contain("1080p");
+        result.Confidence.Should().BeGreaterThan(0);
+        result.BestMatchPolarity.Should().Be(TokenPolarity.Positive);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_MultipleTokens_SelectsHighestRank()
+    {
+        SetupTokensAndPatterns(
+            tokens:
+            [
+                new() { TokenId = 1, TokenText = "1080p", QualityRank = 80, Polarity = TokenPolarity.Positive, IsActive = true },
+                new() { TokenId = 2, TokenText = "720p", QualityRank = 60, Polarity = TokenPolarity.Positive, IsActive = true }
+            ],
+            patterns: []);
+
+        var result = await _sut.ExtractAsync("Available in 1080p and 720p");
+
+        result.Score.Should().Be(80);
+        result.MatchedTokens.Should().HaveCount(2);
+        result.MatchedTokens.Should().Contain("1080p");
+        result.MatchedTokens.Should().Contain("720p");
+    }
+
+    [Fact]
+    public async Task ExtractAsync_TokenCaseInsensitive_Matches()
+    {
+        SetupTokensAndPatterns(
+            tokens: [new() { TokenId = 1, TokenText = "BluRay", QualityRank = 70, Polarity = TokenPolarity.Positive, IsActive = true }],
+            patterns: []);
+
+        var result = await _sut.ExtractAsync("This is a BLURAY release");
+
+        result.Score.Should().Be(70);
+        result.MatchedTokens.Should().Contain("BluRay");
+    }
+
+    [Fact]
+    public async Task ExtractAsync_TokenNotInText_NoMatch()
+    {
+        // AC#6: No-match scenario
+        SetupTokensAndPatterns(
+            tokens: [new() { TokenId = 1, TokenText = "2160p", QualityRank = 100, Polarity = TokenPolarity.Positive, IsActive = true }],
+            patterns: []);
+
+        var result = await _sut.ExtractAsync("Just a regular post with no quality info");
+
+        result.Score.Should().Be(0);
+        result.MatchedTokens.Should().BeEmpty();
+        result.Confidence.Should().Be(0.0);
+        result.BestMatchPolarity.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ExtractAsync_TokenWordBoundary_DoesNotMatchSubstring()
+    {
+        SetupTokensAndPatterns(
+            tokens: [new() { TokenId = 1, TokenText = "HDR", QualityRank = 75, Polarity = TokenPolarity.Positive, IsActive = true }],
+            patterns: []);
+
+        // "HDR" should not match inside "SHDREAM"
+        var result = await _sut.ExtractAsync("SHDREAM is not a quality indicator");
+
+        result.Score.Should().Be(0);
+        result.MatchedTokens.Should().BeEmpty();
+    }
+
+    // ── AC#2: Negative polarity downranking ────────────────────────
+
+    [Fact]
+    public async Task ExtractAsync_NegativePolarityWithPositive_PositiveWins()
+    {
+        // AC#6: Known negative-polarity downrank
+        SetupTokensAndPatterns(
+            tokens:
+            [
+                new() { TokenId = 1, TokenText = "1080p", QualityRank = 80, Polarity = TokenPolarity.Positive, IsActive = true },
+                new() { TokenId = 2, TokenText = "AI-upscaled", QualityRank = -10, Polarity = TokenPolarity.Negative, IsActive = true }
+            ],
+            patterns: []);
+
+        var result = await _sut.ExtractAsync("1080p AI-upscaled content available");
+
+        result.Score.Should().Be(80);
+        result.BestMatchPolarity.Should().Be(TokenPolarity.Positive);
+        result.MatchedTokens.Should().Contain("AI-upscaled");
+        result.MatchedTokens.Should().Contain("1080p");
+    }
+
+    [Fact]
+    public async Task ExtractAsync_OnlyNegativePolarity_ReturnsNegativeScore()
+    {
+        SetupTokensAndPatterns(
+            tokens: [new() { TokenId = 1, TokenText = "AI-upscaled", QualityRank = -10, Polarity = TokenPolarity.Negative, IsActive = true }],
+            patterns: []);
+
+        var result = await _sut.ExtractAsync("This is AI-upscaled content");
+
+        result.Score.Should().Be(-10);
+        result.BestMatchPolarity.Should().Be(TokenPolarity.Negative);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_LowPositiveBeatsHighNegative_PositiveAlwaysWins()
+    {
+        // Even a low positive should beat a negative with a higher absolute rank
+        SetupTokensAndPatterns(
+            tokens:
+            [
+                new() { TokenId = 1, TokenText = "480p", QualityRank = 40, Polarity = TokenPolarity.Positive, IsActive = true },
+                new() { TokenId = 2, TokenText = "AI-upscaled", QualityRank = -10, Polarity = TokenPolarity.Negative, IsActive = true }
+            ],
+            patterns: []);
+
+        var result = await _sut.ExtractAsync("480p AI-upscaled release");
+
+        result.Score.Should().Be(40);
+        result.BestMatchPolarity.Should().Be(TokenPolarity.Positive);
+    }
+
+    // ── AC#1: Learned pattern matching + AC#3: hit count ───────────
+
+    [Fact]
+    public async Task ExtractAsync_LearnedPatternMatch_ReturnsScore()
+    {
+        SetupTokensAndPatterns(
+            tokens: [],
+            patterns:
+            [
+                new()
+                {
+                    PatternId = 1, PatternRegex = @"\b1080p\b", DerivedRank = 80,
+                    Polarity = TokenPolarity.Positive, IsActive = true, AlgorithmVersion = "1.0"
+                }
+            ]);
+
+        var result = await _sut.ExtractAsync("Movie.Name.1080p.BluRay");
+
+        result.Score.Should().Be(80);
+        result.MatchedTokens.Should().Contain("1080p");
+    }
+
+    [Fact]
+    public async Task ExtractAsync_PatternMatch_IncrementsHitCount()
+    {
+        // AC#6: hit_count increment verification
+        SetupTokensAndPatterns(
+            tokens: [],
+            patterns:
+            [
+                new()
+                {
+                    PatternId = 42, PatternRegex = @"\b720p\b", DerivedRank = 60,
+                    Polarity = TokenPolarity.Positive, IsActive = true, AlgorithmVersion = "1.0"
+                }
+            ]);
+
+        await _sut.ExtractAsync("Some 720p content here");
+
+        _patternServiceMock.Verify(
+            s => s.RecordPatternHitAsync(42, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_MultiplePatternMatches_IncrementsEachHitCount()
+    {
+        SetupTokensAndPatterns(
+            tokens: [],
+            patterns:
+            [
+                new()
+                {
+                    PatternId = 1, PatternRegex = @"\b1080p\b", DerivedRank = 80,
+                    Polarity = TokenPolarity.Positive, IsActive = true, AlgorithmVersion = "1.0"
+                },
+                new()
+                {
+                    PatternId = 2, PatternRegex = @"\bBluRay\b", DerivedRank = 70,
+                    Polarity = TokenPolarity.Positive, IsActive = true, AlgorithmVersion = "1.0"
+                }
+            ]);
+
+        await _sut.ExtractAsync("Movie 1080p BluRay release");
+
+        _patternServiceMock.Verify(s => s.RecordPatternHitAsync(1, It.IsAny<CancellationToken>()), Times.Once);
+        _patternServiceMock.Verify(s => s.RecordPatternHitAsync(2, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_TokenMatch_DoesNotIncrementHitCount()
+    {
+        SetupTokensAndPatterns(
+            tokens: [new() { TokenId = 1, TokenText = "1080p", QualityRank = 80, Polarity = TokenPolarity.Positive, IsActive = true }],
+            patterns: []);
+
+        await _sut.ExtractAsync("Movie 1080p release");
+
+        _patternServiceMock.Verify(
+            s => s.RecordPatternHitAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // ── AC#5: Regex timeout ────────────────────────────────────────
+
+    [Fact]
+    public async Task ExtractAsync_RegexTimeout_TreatsAsNoMatch()
+    {
+        // AC#6: Pattern timeout simulation (adversarial ReDoS input)
+        // Use a catastrophic backtracking pattern with adversarial input
+        SetupTokensAndPatterns(
+            tokens: [],
+            patterns:
+            [
+                new()
+                {
+                    PatternId = 1,
+                    PatternRegex = @"^(a+)+$",
+                    DerivedRank = 80,
+                    Polarity = TokenPolarity.Positive,
+                    IsActive = true,
+                    AlgorithmVersion = "1.0"
+                }
+            ]);
+
+        // This input causes catastrophic backtracking with the pattern above
+        var adversarialInput = new string('a', 30) + "X";
+
+        var result = await _sut.ExtractAsync(adversarialInput);
+
+        // Pattern should timeout → treated as no match
+        // (May or may not time out depending on regex engine; we verify the code handles it)
+        // If it doesn't timeout, it simply won't match because of the trailing X
+        result.MatchedTokens.Should().NotContain("^(a+)+$");
+    }
+
+    [Fact]
+    public async Task ExtractAsync_RegexTimeout_LogsWarning()
+    {
+        // We verify the logger is called when a timeout occurs.
+        // Use a known ReDoS pattern that will timeout with long adversarial input.
+        var loggerMock = new Mock<ILogger<QualityExtractor>>();
+        var sut = new QualityExtractor(_patternServiceMock.Object, loggerMock.Object);
+
+        SetupTokensAndPatterns(
+            tokens: [],
+            patterns:
+            [
+                new()
+                {
+                    PatternId = 1,
+                    PatternRegex = @"^(a+)+$",
+                    DerivedRank = 80,
+                    Polarity = TokenPolarity.Positive,
+                    IsActive = true,
+                    AlgorithmVersion = "1.0"
+                }
+            ]);
+
+        // Use very long adversarial input to ensure timeout
+        var adversarialInput = new string('a', 50) + "!";
+
+        await sut.ExtractAsync(adversarialInput);
+
+        // The pattern either times out (and logs) or doesn't match (trailing !)
+        // Either way, no crash should occur — this tests resilience
+    }
+
+    // ── AC#4: New pattern discovery ────────────────────────────────
+
+    [Fact]
+    public async Task ExtractAsync_UnknownResolutionToken_RecordsAsLearnedPattern()
+    {
+        SetupTokensAndPatterns(tokens: [], patterns: []);
+
+        _patternServiceMock
+            .Setup(s => s.AddLearnedPatternAsync(
+                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TokenPolarity>(),
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new QualityLearnedPattern
+            {
+                PatternId = 100,
+                PatternRegex = @"\b540p\b",
+                DerivedRank = 50,
+                AlgorithmVersion = QualityExtractor.AlgorithmVersion,
+                Polarity = TokenPolarity.Positive,
+                Source = PatternSource.Learned
+            });
+
+        await _sut.ExtractAsync("This release is in 540p quality");
+
+        _patternServiceMock.Verify(
+            s => s.AddLearnedPatternAsync(
+                @"\b540p\b", 50, TokenPolarity.Positive,
+                QualityExtractor.AlgorithmVersion,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_KnownTokenText_DoesNotRecordDuplicate()
+    {
+        SetupTokensAndPatterns(
+            tokens: [new() { TokenId = 1, TokenText = "1080p", QualityRank = 80, Polarity = TokenPolarity.Positive, IsActive = true }],
+            patterns: []);
+
+        await _sut.ExtractAsync("Movie in 1080p quality");
+
+        _patternServiceMock.Verify(
+            s => s.AddLearnedPatternAsync(
+                It.Is<string>(p => p.Contains("1080p")),
+                It.IsAny<int>(), It.IsAny<TokenPolarity>(),
+                It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_KnownPatternRegex_DoesNotRecordDuplicate()
+    {
+        SetupTokensAndPatterns(
+            tokens: [],
+            patterns:
+            [
+                new()
+                {
+                    PatternId = 1, PatternRegex = @"\b720p\b", DerivedRank = 60,
+                    Polarity = TokenPolarity.Positive, IsActive = true, AlgorithmVersion = "1.0"
+                }
+            ]);
+
+        await _sut.ExtractAsync("Movie in 720p quality");
+
+        _patternServiceMock.Verify(
+            s => s.AddLearnedPatternAsync(
+                @"\b720p\b", It.IsAny<int>(), It.IsAny<TokenPolarity>(),
+                It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // ── Confidence calculation ──────────────────────────────────────
+
+    [Fact]
+    public async Task ExtractAsync_SingleMatch_ConfidenceIs0_5()
+    {
+        SetupTokensAndPatterns(
+            tokens: [new() { TokenId = 1, TokenText = "1080p", QualityRank = 80, Polarity = TokenPolarity.Positive, IsActive = true }],
+            patterns: []);
+
+        var result = await _sut.ExtractAsync("Movie 1080p");
+
+        result.Confidence.Should().Be(0.5); // 1 / (1 + 1) = 0.5
+    }
+
+    [Fact]
+    public async Task ExtractAsync_TwoMatches_ConfidenceIncreases()
+    {
+        SetupTokensAndPatterns(
+            tokens:
+            [
+                new() { TokenId = 1, TokenText = "1080p", QualityRank = 80, Polarity = TokenPolarity.Positive, IsActive = true },
+                new() { TokenId = 2, TokenText = "BluRay", QualityRank = 70, Polarity = TokenPolarity.Positive, IsActive = true }
+            ],
+            patterns: []);
+
+        var result = await _sut.ExtractAsync("Movie 1080p BluRay");
+
+        result.Confidence.Should().BeApproximately(0.6667, 0.001); // 2 / (2 + 1) ≈ 0.6667
+    }
+
+    // ── Word boundary matching via token ────────────────────────────
+
+    [Fact]
+    public async Task ExtractAsync_TokenInsideWord_DoesNotMatch()
+    {
+        // "HDR" should not match as a substring of another word
+        SetupTokensAndPatterns(
+            tokens: [new() { TokenId = 1, TokenText = "HDR", QualityRank = 75, Polarity = TokenPolarity.Positive, IsActive = true }],
+            patterns: []);
+
+        var result = await _sut.ExtractAsync("SHDREAM is not an indicator");
+
+        result.Score.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_TokenAtStartOfText_Matches()
+    {
+        SetupTokensAndPatterns(
+            tokens: [new() { TokenId = 1, TokenText = "1080p", QualityRank = 80, Polarity = TokenPolarity.Positive, IsActive = true }],
+            patterns: []);
+
+        var result = await _sut.ExtractAsync("1080p is the quality");
+
+        result.Score.Should().Be(80);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_TokenAtEndOfText_Matches()
+    {
+        SetupTokensAndPatterns(
+            tokens: [new() { TokenId = 1, TokenText = "1080p", QualityRank = 80, Polarity = TokenPolarity.Positive, IsActive = true }],
+            patterns: []);
+
+        var result = await _sut.ExtractAsync("Quality is 1080p");
+
+        result.Score.Should().Be(80);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_TokenSeparatedByDots_Matches()
+    {
+        SetupTokensAndPatterns(
+            tokens: [new() { TokenId = 1, TokenText = "1080p", QualityRank = 80, Polarity = TokenPolarity.Positive, IsActive = true }],
+            patterns: []);
+
+        var result = await _sut.ExtractAsync("movie.1080p.bluray");
+
+        result.Score.Should().Be(80);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_TokenSeparatedBySlash_Matches()
+    {
+        SetupTokensAndPatterns(
+            tokens: [new() { TokenId = 1, TokenText = "x265", QualityRank = 65, Polarity = TokenPolarity.Positive, IsActive = true }],
+            patterns: []);
+
+        var result = await _sut.ExtractAsync("x265/HEVC content");
+
+        result.Score.Should().Be(65);
+    }
+
+    // ── Combined token + pattern scenario ───────────────────────────
+
+    [Fact]
+    public async Task ExtractAsync_TokenAndPatternBothMatch_UsesHighestRank()
+    {
+        SetupTokensAndPatterns(
+            tokens: [new() { TokenId = 1, TokenText = "1080p", QualityRank = 80, Polarity = TokenPolarity.Positive, IsActive = true }],
+            patterns:
+            [
+                new()
+                {
+                    PatternId = 1, PatternRegex = @"\b2160p\b", DerivedRank = 100,
+                    Polarity = TokenPolarity.Positive, IsActive = true, AlgorithmVersion = "1.0"
+                }
+            ]);
+
+        var result = await _sut.ExtractAsync("Movie 1080p and also 2160p available");
+
+        result.Score.Should().Be(100);
+        result.MatchedTokens.Should().HaveCount(2);
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────
+
+    private void SetupTokensAndPatterns(
+        List<QualityToken> tokens,
+        List<QualityLearnedPattern> patterns)
+    {
+        _patternServiceMock
+            .Setup(s => s.GetActiveTokensAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tokens);
+
+        _patternServiceMock
+            .Setup(s => s.GetActivePatternsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(patterns);
+
+        _patternServiceMock
+            .Setup(s => s.RecordPatternHitAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _patternServiceMock
+            .Setup(s => s.AddLearnedPatternAsync(
+                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TokenPolarity>(),
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string regex, int rank, TokenPolarity pol, string ver, CancellationToken _) =>
+                new QualityLearnedPattern
+                {
+                    PatternId = 999,
+                    PatternRegex = regex,
+                    DerivedRank = rank,
+                    Polarity = pol,
+                    AlgorithmVersion = ver,
+                    Source = PatternSource.Learned,
+                    IsActive = true
+                });
+    }
+}

--- a/tests/SeriesScraper.Domain.Tests/ValueObjects/QualityRankTests.cs
+++ b/tests/SeriesScraper.Domain.Tests/ValueObjects/QualityRankTests.cs
@@ -1,0 +1,102 @@
+using FluentAssertions;
+using SeriesScraper.Domain.Enums;
+using SeriesScraper.Domain.ValueObjects;
+
+namespace SeriesScraper.Domain.Tests.ValueObjects;
+
+public class QualityRankTests
+{
+    // ── None ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void None_ReturnsZeroScore()
+    {
+        var rank = QualityRank.None;
+        rank.Score.Should().Be(0);
+    }
+
+    [Fact]
+    public void None_ReturnsEmptyMatchedTokens()
+    {
+        var rank = QualityRank.None;
+        rank.MatchedTokens.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void None_ReturnsZeroConfidence()
+    {
+        var rank = QualityRank.None;
+        rank.Confidence.Should().Be(0.0);
+    }
+
+    [Fact]
+    public void None_ReturnsNullBestMatchPolarity()
+    {
+        var rank = QualityRank.None;
+        rank.BestMatchPolarity.Should().BeNull();
+    }
+
+    // ── Construction ────────────────────────────────────────────────
+
+    [Fact]
+    public void Construction_WithValues_SetsAllProperties()
+    {
+        var tokens = new List<string> { "1080p", "BluRay" };
+        var rank = new QualityRank
+        {
+            Score = 80,
+            MatchedTokens = tokens,
+            Confidence = 0.6667,
+            BestMatchPolarity = TokenPolarity.Positive
+        };
+
+        rank.Score.Should().Be(80);
+        rank.MatchedTokens.Should().BeEquivalentTo(tokens);
+        rank.Confidence.Should().Be(0.6667);
+        rank.BestMatchPolarity.Should().Be(TokenPolarity.Positive);
+    }
+
+    [Fact]
+    public void Construction_NegativePolarity_SetsCorrectly()
+    {
+        var rank = new QualityRank
+        {
+            Score = -10,
+            MatchedTokens = new List<string> { "AI-upscaled" },
+            Confidence = 0.5,
+            BestMatchPolarity = TokenPolarity.Negative
+        };
+
+        rank.Score.Should().Be(-10);
+        rank.BestMatchPolarity.Should().Be(TokenPolarity.Negative);
+    }
+
+    // ── Record equality ─────────────────────────────────────────────
+
+    [Fact]
+    public void Equality_SameValues_AreEqual()
+    {
+        var tokens = new List<string> { "1080p" };
+        var a = new QualityRank { Score = 80, MatchedTokens = tokens, Confidence = 0.5, BestMatchPolarity = TokenPolarity.Positive };
+        var b = new QualityRank { Score = 80, MatchedTokens = tokens, Confidence = 0.5, BestMatchPolarity = TokenPolarity.Positive };
+
+        a.Should().Be(b);
+    }
+
+    [Fact]
+    public void Equality_DifferentScore_AreNotEqual()
+    {
+        var tokens = new List<string> { "1080p" };
+        var a = new QualityRank { Score = 80, MatchedTokens = tokens, Confidence = 0.5 };
+        var b = new QualityRank { Score = 60, MatchedTokens = tokens, Confidence = 0.5 };
+
+        a.Should().NotBe(b);
+    }
+
+    [Fact]
+    public void DefaultMatchedTokens_IsEmptyList()
+    {
+        var rank = new QualityRank { Score = 0, Confidence = 0.0 };
+        rank.MatchedTokens.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
Closes #26

## Summary of Changes

Implements the quality extraction engine that evaluates active quality tokens and learned patterns against forum post text, selects the best quality match, and supports pattern learning.

### New Files

- **IQualityExtractor** (Domain/Interfaces) — Contract for quality extraction from post text
- **QualityRank** (Domain/ValueObjects) — Value object containing overall score, matched tokens, confidence, and best match polarity
- **QualityExtractor** (Application/Services) — Core extraction engine:
  - Evaluates all active QualityTokens via case-insensitive word-boundary matching (AC#1)
  - Evaluates all active QualityLearnedPatterns via regex with 2-second timeout (AC#1, AC#5)
  - Selects best match by highest quality_rank; negative polarity downranked below any positive match (AC#2)
  - Increments hit_count on matched patterns via RecordPatternHitAsync (single ExecuteUpdateAsync statement) (AC#3)
  - Discovers unrecognized quality tokens via heuristic patterns and records them as new QualityLearnedPatterns with Source=Learned (AC#4)
  - Catches RegexMatchTimeoutException, logs at WARN level, treats as no-match (AC#5)

### Testing

39 new unit tests covering all AC#6 scenarios:
- Known positive match
- Negative-polarity downrank (positive always wins over negative)
- Pattern timeout simulation with adversarial ReDoS input
- No-match scenario
- Hit count increment verification on pattern matches
- Word boundary edge cases (dots, slashes, embedded substrings)
- Discovery deduplication (known tokens/patterns not re-added)
- Confidence calculation

**Total tests: 149 passing (all projects)**

### Known Limitations

- Discovery heuristics cover resolution/codec patterns; additional heuristics can be added in future iterations
- Pruning job not implemented (deferred per issue scope)