### PR TITLE
feat(#29): Link extraction, parsing, and completeness check

### DIFF
--- a/src/SeriesScraper.Application/SeriesScraper.Application.csproj
+++ b/src/SeriesScraper.Application/SeriesScraper.Application.csproj
@@ -14,4 +14,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="SeriesScraper.Application.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/SeriesScraper.Application/Services/CompletenessCheckerService.cs
+++ b/src/SeriesScraper.Application/Services/CompletenessCheckerService.cs
@@ -1,0 +1,84 @@
+using Microsoft.Extensions.Logging;
+using SeriesScraper.Domain.Entities;
+using SeriesScraper.Domain.Enums;
+using SeriesScraper.Domain.Interfaces;
+
+namespace SeriesScraper.Application.Services;
+
+public class CompletenessCheckerService : ICompletenessCheckerService
+{
+    private readonly IMediaEpisodeRepository _episodeRepository;
+    private readonly ILogger<CompletenessCheckerService> _logger;
+
+    public CompletenessCheckerService(
+        IMediaEpisodeRepository episodeRepository,
+        ILogger<CompletenessCheckerService> logger)
+    {
+        _episodeRepository = episodeRepository;
+        _logger = logger;
+    }
+
+    public async Task<CompletenessStatus> CheckCompletenessAsync(
+        int mediaId,
+        MediaType mediaType,
+        IReadOnlyList<Link> links,
+        CancellationToken ct = default)
+    {
+        if (links.Count == 0)
+            return CompletenessStatus.Incomplete;
+
+        // AC#4: Movies — at least one link = Complete
+        if (mediaType == MediaType.Movie)
+            return CompletenessStatus.Complete;
+
+        // AC#3: TV Series completeness check
+        if (mediaType == MediaType.Series)
+            return await CheckSeriesCompletenessAsync(mediaId, links, ct);
+
+        return CompletenessStatus.Unknown;
+    }
+
+    private async Task<CompletenessStatus> CheckSeriesCompletenessAsync(
+        int mediaId,
+        IReadOnlyList<Link> links,
+        CancellationToken ct)
+    {
+        // Heuristic: if any link has no episode number (and possibly no season),
+        // it may cover a whole series/season archive → treat as Complete
+        var hasArchiveLink = links.Any(l => l.ParsedEpisode is null);
+        if (hasArchiveLink)
+        {
+            _logger.LogDebug(
+                "Media {MediaId}: found link without episode number, treating as archive → Complete",
+                mediaId);
+            return CompletenessStatus.Complete;
+        }
+
+        var seasons = await _episodeRepository.GetSeasonsAsync(mediaId, ct);
+        if (seasons.Count == 0)
+        {
+            _logger.LogDebug("Media {MediaId}: no episodes in metadata, cannot verify completeness", mediaId);
+            return CompletenessStatus.Unknown;
+        }
+
+        foreach (var season in seasons)
+        {
+            var expectedCount = await _episodeRepository.GetEpisodeCountForSeasonAsync(mediaId, season, ct);
+            var actualCount = links
+                .Where(l => l.ParsedSeason == season && l.ParsedEpisode.HasValue)
+                .Select(l => l.ParsedEpisode!.Value)
+                .Distinct()
+                .Count();
+
+            if (actualCount < expectedCount)
+            {
+                _logger.LogDebug(
+                    "Media {MediaId} Season {Season}: {Actual}/{Expected} episodes → Incomplete",
+                    mediaId, season, actualCount, expectedCount);
+                return CompletenessStatus.Incomplete;
+            }
+        }
+
+        return CompletenessStatus.Complete;
+    }
+}

--- a/src/SeriesScraper.Application/Services/LinkExtractorService.cs
+++ b/src/SeriesScraper.Application/Services/LinkExtractorService.cs
@@ -1,0 +1,173 @@
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
+using SeriesScraper.Domain.Entities;
+using SeriesScraper.Domain.Interfaces;
+
+namespace SeriesScraper.Application.Services;
+
+public class LinkExtractorService : ILinkExtractorService
+{
+    private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(2);
+
+    // Allowed URL schemes per AC#5
+    private static readonly HashSet<string> AllowedSchemes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "http", "https", "magnet", "torrent"
+    };
+
+    // Extract URLs from href attributes and plain-text URLs
+    private static readonly Regex HrefPattern = new(
+        @"href\s*=\s*[""']([^""']+)[""']",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled,
+        RegexTimeout);
+
+    private static readonly Regex PlainUrlPattern = new(
+        @"(?:https?|magnet|torrent):[^\s<>""']+",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled,
+        RegexTimeout);
+
+    // Season/episode parsing patterns
+    private static readonly Regex SeasonEpisodePattern = new(
+        @"[Ss](\d{1,3})[Ee](\d{1,3})",
+        RegexOptions.Compiled,
+        RegexTimeout);
+
+    private static readonly Regex SeasonOnlyPattern = new(
+        @"[Ss](?:eason)?[.\-_]?(\d{1,3})",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled,
+        RegexTimeout);
+
+    private static readonly Regex EpisodeOnlyPattern = new(
+        @"(?<![a-zA-Z])[Ee](?:pisode)?[.\-_]?(\d{1,3})",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled,
+        RegexTimeout);
+
+    private readonly ILinkTypeService _linkTypeService;
+    private readonly ILogger<LinkExtractorService> _logger;
+
+    public LinkExtractorService(ILinkTypeService linkTypeService, ILogger<LinkExtractorService> logger)
+    {
+        _linkTypeService = linkTypeService;
+        _logger = logger;
+    }
+
+    public async Task<IReadOnlyList<Link>> ExtractLinksAsync(string postHtml, int runId, string postUrl, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(postHtml))
+            return Array.Empty<Link>();
+
+        var urls = ExtractUrls(postHtml);
+        var linkTypes = await _linkTypeService.GetActiveAsync(ct);
+        var links = new List<Link>();
+
+        foreach (var url in urls)
+        {
+            if (!IsAllowedScheme(url))
+                continue;
+
+            var linkTypeId = _linkTypeService.ClassifyUrl(url, linkTypes);
+            if (linkTypeId is null)
+            {
+                _logger.LogDebug("URL {Url} did not match any active link type, skipping", url);
+                continue;
+            }
+
+            var (season, episode) = ParseSeasonEpisode(url);
+
+            links.Add(new Link
+            {
+                Url = url,
+                PostUrl = postUrl,
+                LinkTypeId = linkTypeId.Value,
+                ParsedSeason = season,
+                ParsedEpisode = episode,
+                RunId = runId,
+                IsCurrent = true,
+                CreatedAt = DateTime.UtcNow
+            });
+        }
+
+        return links;
+    }
+
+    internal static IReadOnlyList<string> ExtractUrls(string html)
+    {
+        var urls = new HashSet<string>(StringComparer.Ordinal);
+
+        try
+        {
+            foreach (Match match in HrefPattern.Matches(html))
+            {
+                var url = match.Groups[1].Value.Trim();
+                if (!string.IsNullOrEmpty(url))
+                    urls.Add(url);
+            }
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            // Safety: href extraction timed out
+        }
+
+        try
+        {
+            foreach (Match match in PlainUrlPattern.Matches(html))
+            {
+                var url = match.Value.Trim();
+                if (!string.IsNullOrEmpty(url))
+                    urls.Add(url);
+            }
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            // Safety: plain URL extraction timed out
+        }
+
+        return urls.ToList();
+    }
+
+    internal static bool IsAllowedScheme(string url)
+    {
+        // Magnet URIs use "magnet:" not "magnet://"
+        if (url.StartsWith("magnet:", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        if (Uri.TryCreate(url, UriKind.Absolute, out var uri))
+            return AllowedSchemes.Contains(uri.Scheme);
+
+        return false;
+    }
+
+    internal static (int? Season, int? Episode) ParseSeasonEpisode(string url)
+    {
+        try
+        {
+            // Try S01E02 pattern first
+            var seMatch = SeasonEpisodePattern.Match(url);
+            if (seMatch.Success)
+            {
+                return (
+                    int.Parse(seMatch.Groups[1].Value),
+                    int.Parse(seMatch.Groups[2].Value)
+                );
+            }
+
+            // Season-only pattern
+            int? season = null;
+            var sMatch = SeasonOnlyPattern.Match(url);
+            if (sMatch.Success)
+                season = int.Parse(sMatch.Groups[1].Value);
+
+            // Episode-only pattern
+            int? episode = null;
+            var eMatch = EpisodeOnlyPattern.Match(url);
+            if (eMatch.Success)
+                episode = int.Parse(eMatch.Groups[1].Value);
+
+            return (season, episode);
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            return (null, null);
+        }
+    }
+}

--- a/src/SeriesScraper.Domain/Entities/Link.cs
+++ b/src/SeriesScraper.Domain/Entities/Link.cs
@@ -11,6 +11,11 @@ public class Link
     public int LinkTypeId { get; set; }
     
     /// <summary>
+    /// Source post URL — used for accumulate-with-flag scoping per AC#7.
+    /// </summary>
+    public required string PostUrl { get; set; }
+    
+    /// <summary>
     /// Null = parsing failed or not applicable (movies).
     /// </summary>
     public int? ParsedSeason { get; set; }

--- a/src/SeriesScraper.Domain/Enums/CompletenessStatus.cs
+++ b/src/SeriesScraper.Domain/Enums/CompletenessStatus.cs
@@ -1,0 +1,8 @@
+namespace SeriesScraper.Domain.Enums;
+
+public enum CompletenessStatus
+{
+    Complete,
+    Incomplete,
+    Unknown
+}

--- a/src/SeriesScraper.Domain/Interfaces/ICompletenessCheckerService.cs
+++ b/src/SeriesScraper.Domain/Interfaces/ICompletenessCheckerService.cs
@@ -1,0 +1,12 @@
+using SeriesScraper.Domain.Enums;
+
+namespace SeriesScraper.Domain.Interfaces;
+
+public interface ICompletenessCheckerService
+{
+    Task<CompletenessStatus> CheckCompletenessAsync(
+        int mediaId,
+        MediaType mediaType,
+        IReadOnlyList<Domain.Entities.Link> links,
+        CancellationToken ct = default);
+}

--- a/src/SeriesScraper.Domain/Interfaces/ILinkExtractorService.cs
+++ b/src/SeriesScraper.Domain/Interfaces/ILinkExtractorService.cs
@@ -1,0 +1,8 @@
+using SeriesScraper.Domain.Entities;
+
+namespace SeriesScraper.Domain.Interfaces;
+
+public interface ILinkExtractorService
+{
+    Task<IReadOnlyList<Link>> ExtractLinksAsync(string postHtml, int runId, string postUrl, CancellationToken ct = default);
+}

--- a/src/SeriesScraper.Domain/Interfaces/ILinkRepository.cs
+++ b/src/SeriesScraper.Domain/Interfaces/ILinkRepository.cs
@@ -1,0 +1,12 @@
+using SeriesScraper.Domain.Entities;
+
+namespace SeriesScraper.Domain.Interfaces;
+
+public interface ILinkRepository
+{
+    Task<IReadOnlyList<Link>> GetCurrentByRunIdAsync(int runId, CancellationToken ct = default);
+    Task<IReadOnlyList<Link>> GetCurrentByPostUrlAsync(string postUrl, int runId, CancellationToken ct = default);
+    Task AddRangeAsync(IEnumerable<Link> links, CancellationToken ct = default);
+    Task MarkPreviousAsNonCurrentAsync(int runId, string postUrl, CancellationToken ct = default);
+    Task AccumulateLinksAsync(int runId, string postUrl, IEnumerable<Link> newLinks, CancellationToken ct = default);
+}

--- a/src/SeriesScraper.Domain/Interfaces/IMediaEpisodeRepository.cs
+++ b/src/SeriesScraper.Domain/Interfaces/IMediaEpisodeRepository.cs
@@ -1,0 +1,10 @@
+using SeriesScraper.Domain.Entities;
+
+namespace SeriesScraper.Domain.Interfaces;
+
+public interface IMediaEpisodeRepository
+{
+    Task<IReadOnlyList<MediaEpisode>> GetByMediaIdAsync(int mediaId, CancellationToken ct = default);
+    Task<int> GetEpisodeCountForSeasonAsync(int mediaId, int season, CancellationToken ct = default);
+    Task<IReadOnlyList<int>> GetSeasonsAsync(int mediaId, CancellationToken ct = default);
+}

--- a/src/SeriesScraper.Infrastructure/Data/Configurations/LinkConfiguration.cs
+++ b/src/SeriesScraper.Infrastructure/Data/Configurations/LinkConfiguration.cs
@@ -19,6 +19,10 @@ public class LinkConfiguration : IEntityTypeConfiguration<Link>
             .IsRequired()
             .HasMaxLength(2000);
         
+        entity.Property(e => e.PostUrl)
+            .IsRequired()
+            .HasMaxLength(2000);
+        
         entity.Property(e => e.CreatedAt)
             .HasColumnType("timestamp with time zone")
             .HasDefaultValueSql("CURRENT_TIMESTAMP");
@@ -35,6 +39,9 @@ public class LinkConfiguration : IEntityTypeConfiguration<Link>
             .WithMany(r => r.Links)
             .HasForeignKey(e => e.RunId)
             .OnDelete(DeleteBehavior.Cascade);
+        
+        // Index for accumulate-with-flag queries per AC#7
+        entity.HasIndex(e => new { e.RunId, e.PostUrl, e.IsCurrent });
         
         // NOTE: Partial index IX_Links_IsCurrentPartial created via raw SQL in migration Up() per AC#1
         // CREATE INDEX IX_Links_IsCurrentPartial ON links (link_id) WHERE is_current = true;

--- a/src/SeriesScraper.Infrastructure/Data/LinkRepository.cs
+++ b/src/SeriesScraper.Infrastructure/Data/LinkRepository.cs
@@ -1,0 +1,71 @@
+using Microsoft.EntityFrameworkCore;
+using SeriesScraper.Domain.Entities;
+using SeriesScraper.Domain.Interfaces;
+
+namespace SeriesScraper.Infrastructure.Data;
+
+public class LinkRepository : ILinkRepository
+{
+    private readonly AppDbContext _context;
+
+    public LinkRepository(AppDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<IReadOnlyList<Link>> GetCurrentByRunIdAsync(int runId, CancellationToken ct = default)
+    {
+        return await _context.Links
+            .Where(l => l.RunId == runId && l.IsCurrent)
+            .AsNoTracking()
+            .ToListAsync(ct);
+    }
+
+    public async Task<IReadOnlyList<Link>> GetCurrentByPostUrlAsync(string postUrl, int runId, CancellationToken ct = default)
+    {
+        return await _context.Links
+            .Where(l => l.PostUrl == postUrl && l.RunId == runId && l.IsCurrent)
+            .AsNoTracking()
+            .ToListAsync(ct);
+    }
+
+    public async Task AddRangeAsync(IEnumerable<Link> links, CancellationToken ct = default)
+    {
+        _context.Links.AddRange(links);
+        await _context.SaveChangesAsync(ct);
+    }
+
+    public async Task MarkPreviousAsNonCurrentAsync(int runId, string postUrl, CancellationToken ct = default)
+    {
+        var links = await _context.Links
+            .Where(l => l.RunId == runId && l.PostUrl == postUrl && l.IsCurrent)
+            .ToListAsync(ct);
+
+        foreach (var link in links)
+            link.IsCurrent = false;
+
+        await _context.SaveChangesAsync(ct);
+    }
+
+    /// <summary>
+    /// Accumulate-with-flag pattern per AC#7:
+    /// Mark existing links as non-current and insert new links atomically.
+    /// SaveChangesAsync wraps all pending changes in a single database transaction.
+    /// </summary>
+    public async Task AccumulateLinksAsync(int runId, string postUrl, IEnumerable<Link> newLinks, CancellationToken ct = default)
+    {
+        // Mark existing links for this post as non-current
+        var existing = await _context.Links
+            .Where(l => l.RunId == runId && l.PostUrl == postUrl && l.IsCurrent)
+            .ToListAsync(ct);
+
+        foreach (var link in existing)
+            link.IsCurrent = false;
+
+        // Insert new links with is_current = true
+        _context.Links.AddRange(newLinks);
+
+        // Single SaveChangesAsync = single transaction (atomic)
+        await _context.SaveChangesAsync(ct);
+    }
+}

--- a/src/SeriesScraper.Infrastructure/Data/MediaEpisodeRepository.cs
+++ b/src/SeriesScraper.Infrastructure/Data/MediaEpisodeRepository.cs
@@ -1,0 +1,41 @@
+using Microsoft.EntityFrameworkCore;
+using SeriesScraper.Domain.Entities;
+using SeriesScraper.Domain.Interfaces;
+
+namespace SeriesScraper.Infrastructure.Data;
+
+public class MediaEpisodeRepository : IMediaEpisodeRepository
+{
+    private readonly AppDbContext _context;
+
+    public MediaEpisodeRepository(AppDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<IReadOnlyList<MediaEpisode>> GetByMediaIdAsync(int mediaId, CancellationToken ct = default)
+    {
+        return await _context.MediaEpisodes
+            .Where(e => e.MediaId == mediaId)
+            .OrderBy(e => e.Season)
+            .ThenBy(e => e.EpisodeNumber)
+            .AsNoTracking()
+            .ToListAsync(ct);
+    }
+
+    public async Task<int> GetEpisodeCountForSeasonAsync(int mediaId, int season, CancellationToken ct = default)
+    {
+        return await _context.MediaEpisodes
+            .CountAsync(e => e.MediaId == mediaId && e.Season == season, ct);
+    }
+
+    public async Task<IReadOnlyList<int>> GetSeasonsAsync(int mediaId, CancellationToken ct = default)
+    {
+        return await _context.MediaEpisodes
+            .Where(e => e.MediaId == mediaId)
+            .Select(e => e.Season)
+            .Distinct()
+            .OrderBy(s => s)
+            .ToListAsync(ct);
+    }
+}

--- a/tests/SeriesScraper.Application.Tests/Services/CompletenessCheckerServiceTests.cs
+++ b/tests/SeriesScraper.Application.Tests/Services/CompletenessCheckerServiceTests.cs
@@ -1,0 +1,255 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using SeriesScraper.Application.Services;
+using SeriesScraper.Domain.Entities;
+using SeriesScraper.Domain.Enums;
+using SeriesScraper.Domain.Interfaces;
+
+namespace SeriesScraper.Application.Tests.Services;
+
+public class CompletenessCheckerServiceTests
+{
+    private readonly Mock<IMediaEpisodeRepository> _episodeRepoMock = new();
+    private readonly Mock<ILogger<CompletenessCheckerService>> _loggerMock = new();
+    private readonly CompletenessCheckerService _sut;
+
+    public CompletenessCheckerServiceTests()
+    {
+        _sut = new CompletenessCheckerService(_episodeRepoMock.Object, _loggerMock.Object);
+    }
+
+    // ── Movies ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task CheckCompleteness_Movie_NoLinks_ReturnsIncomplete()
+    {
+        var result = await _sut.CheckCompletenessAsync(1, MediaType.Movie, Array.Empty<Link>());
+
+        result.Should().Be(CompletenessStatus.Incomplete);
+    }
+
+    [Fact]
+    public async Task CheckCompleteness_Movie_WithLink_ReturnsComplete()
+    {
+        var links = new List<Link>
+        {
+            CreateLink("https://example.com/movie.zip")
+        };
+
+        var result = await _sut.CheckCompletenessAsync(1, MediaType.Movie, links);
+
+        result.Should().Be(CompletenessStatus.Complete);
+    }
+
+    [Fact]
+    public async Task CheckCompleteness_Movie_MultipleLinks_ReturnsComplete()
+    {
+        var links = new List<Link>
+        {
+            CreateLink("https://example.com/movie-720p.zip"),
+            CreateLink("https://example.com/movie-1080p.zip")
+        };
+
+        var result = await _sut.CheckCompletenessAsync(1, MediaType.Movie, links);
+
+        result.Should().Be(CompletenessStatus.Complete);
+    }
+
+    // ── Series — Complete ────────────────────────────────────
+
+    [Fact]
+    public async Task CheckCompleteness_Series_AllEpisodesPresent_ReturnsComplete()
+    {
+        _episodeRepoMock.Setup(r => r.GetSeasonsAsync(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<int> { 1 });
+        _episodeRepoMock.Setup(r => r.GetEpisodeCountForSeasonAsync(1, 1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(3);
+
+        var links = new List<Link>
+        {
+            CreateLink("https://example.com/S01E01.zip", season: 1, episode: 1),
+            CreateLink("https://example.com/S01E02.zip", season: 1, episode: 2),
+            CreateLink("https://example.com/S01E03.zip", season: 1, episode: 3)
+        };
+
+        var result = await _sut.CheckCompletenessAsync(1, MediaType.Series, links);
+
+        result.Should().Be(CompletenessStatus.Complete);
+    }
+
+    [Fact]
+    public async Task CheckCompleteness_Series_ArchiveLink_ReturnsComplete()
+    {
+        // Heuristic: link without episode number → archive → Complete
+        var links = new List<Link>
+        {
+            CreateLink("https://example.com/series-complete.zip", season: null, episode: null)
+        };
+
+        var result = await _sut.CheckCompletenessAsync(1, MediaType.Series, links);
+
+        result.Should().Be(CompletenessStatus.Complete);
+    }
+
+    [Fact]
+    public async Task CheckCompleteness_Series_SeasonArchiveLink_ReturnsComplete()
+    {
+        // Link with season but no episode → season archive → Complete
+        var links = new List<Link>
+        {
+            CreateLink("https://example.com/S01-complete.zip", season: 1, episode: null)
+        };
+
+        var result = await _sut.CheckCompletenessAsync(1, MediaType.Series, links);
+
+        result.Should().Be(CompletenessStatus.Complete);
+    }
+
+    // ── Series — Incomplete ─────────────────────────────────
+
+    [Fact]
+    public async Task CheckCompleteness_Series_MissingEpisodes_ReturnsIncomplete()
+    {
+        _episodeRepoMock.Setup(r => r.GetSeasonsAsync(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<int> { 1 });
+        _episodeRepoMock.Setup(r => r.GetEpisodeCountForSeasonAsync(1, 1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(5);
+
+        var links = new List<Link>
+        {
+            CreateLink("https://example.com/S01E01.zip", season: 1, episode: 1),
+            CreateLink("https://example.com/S01E03.zip", season: 1, episode: 3)
+        };
+
+        var result = await _sut.CheckCompletenessAsync(1, MediaType.Series, links);
+
+        result.Should().Be(CompletenessStatus.Incomplete);
+    }
+
+    [Fact]
+    public async Task CheckCompleteness_Series_NoLinks_ReturnsIncomplete()
+    {
+        var result = await _sut.CheckCompletenessAsync(1, MediaType.Series, Array.Empty<Link>());
+
+        result.Should().Be(CompletenessStatus.Incomplete);
+    }
+
+    // ── Series — Unknown ─────────────────────────────────────
+
+    [Fact]
+    public async Task CheckCompleteness_Series_NoEpisodesInMetadata_ReturnsUnknown()
+    {
+        _episodeRepoMock.Setup(r => r.GetSeasonsAsync(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<int>());
+
+        var links = new List<Link>
+        {
+            CreateLink("https://example.com/S01E01.zip", season: 1, episode: 1)
+        };
+
+        var result = await _sut.CheckCompletenessAsync(1, MediaType.Series, links);
+
+        result.Should().Be(CompletenessStatus.Unknown);
+    }
+
+    // ── Episode type ─────────────────────────────────────────
+
+    [Fact]
+    public async Task CheckCompleteness_EpisodeType_ReturnsUnknown()
+    {
+        var links = new List<Link>
+        {
+            CreateLink("https://example.com/file.zip")
+        };
+
+        var result = await _sut.CheckCompletenessAsync(1, MediaType.Episode, links);
+
+        result.Should().Be(CompletenessStatus.Unknown);
+    }
+
+    // ── Multi-season ─────────────────────────────────────────
+
+    [Fact]
+    public async Task CheckCompleteness_Series_MultiSeason_AllComplete_ReturnsComplete()
+    {
+        _episodeRepoMock.Setup(r => r.GetSeasonsAsync(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<int> { 1, 2 });
+        _episodeRepoMock.Setup(r => r.GetEpisodeCountForSeasonAsync(1, 1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(2);
+        _episodeRepoMock.Setup(r => r.GetEpisodeCountForSeasonAsync(1, 2, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(2);
+
+        var links = new List<Link>
+        {
+            CreateLink("https://example.com/S01E01.zip", season: 1, episode: 1),
+            CreateLink("https://example.com/S01E02.zip", season: 1, episode: 2),
+            CreateLink("https://example.com/S02E01.zip", season: 2, episode: 1),
+            CreateLink("https://example.com/S02E02.zip", season: 2, episode: 2)
+        };
+
+        var result = await _sut.CheckCompletenessAsync(1, MediaType.Series, links);
+
+        result.Should().Be(CompletenessStatus.Complete);
+    }
+
+    [Fact]
+    public async Task CheckCompleteness_Series_MultiSeason_OneIncomplete_ReturnsIncomplete()
+    {
+        _episodeRepoMock.Setup(r => r.GetSeasonsAsync(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<int> { 1, 2 });
+        _episodeRepoMock.Setup(r => r.GetEpisodeCountForSeasonAsync(1, 1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(2);
+        _episodeRepoMock.Setup(r => r.GetEpisodeCountForSeasonAsync(1, 2, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(3);
+
+        var links = new List<Link>
+        {
+            CreateLink("https://example.com/S01E01.zip", season: 1, episode: 1),
+            CreateLink("https://example.com/S01E02.zip", season: 1, episode: 2),
+            CreateLink("https://example.com/S02E01.zip", season: 2, episode: 1)
+        };
+
+        var result = await _sut.CheckCompletenessAsync(1, MediaType.Series, links);
+
+        result.Should().Be(CompletenessStatus.Incomplete);
+    }
+
+    [Fact]
+    public async Task CheckCompleteness_Series_DuplicateEpisodeLinks_CountsDistinct()
+    {
+        _episodeRepoMock.Setup(r => r.GetSeasonsAsync(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<int> { 1 });
+        _episodeRepoMock.Setup(r => r.GetEpisodeCountForSeasonAsync(1, 1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(2);
+
+        // Two links for the same episode — should count as 1
+        var links = new List<Link>
+        {
+            CreateLink("https://example.com/S01E01-720p.zip", season: 1, episode: 1),
+            CreateLink("https://example.com/S01E01-1080p.zip", season: 1, episode: 1),
+            CreateLink("https://example.com/S01E02.zip", season: 1, episode: 2)
+        };
+
+        var result = await _sut.CheckCompletenessAsync(1, MediaType.Series, links);
+
+        result.Should().Be(CompletenessStatus.Complete);
+    }
+
+    // ── Helper ───────────────────────────────────────────────
+
+    private static Link CreateLink(string url, int? season = null, int? episode = null)
+    {
+        return new Link
+        {
+            Url = url,
+            PostUrl = "https://forum.example.com/post/1",
+            LinkTypeId = 1,
+            ParsedSeason = season,
+            ParsedEpisode = episode,
+            RunId = 1,
+            IsCurrent = true,
+            CreatedAt = DateTime.UtcNow
+        };
+    }
+}

--- a/tests/SeriesScraper.Application.Tests/Services/LinkExtractorServiceTests.cs
+++ b/tests/SeriesScraper.Application.Tests/Services/LinkExtractorServiceTests.cs
@@ -1,0 +1,310 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using SeriesScraper.Application.Services;
+using SeriesScraper.Domain.Entities;
+using SeriesScraper.Domain.Interfaces;
+
+namespace SeriesScraper.Application.Tests.Services;
+
+public class LinkExtractorServiceTests
+{
+    private readonly Mock<ILinkTypeService> _linkTypeServiceMock = new();
+    private readonly Mock<ILogger<LinkExtractorService>> _loggerMock = new();
+    private readonly LinkExtractorService _sut;
+
+    private static readonly List<LinkType> DefaultLinkTypes = new()
+    {
+        new() { LinkTypeId = 1, Name = "Direct HTTP", UrlPattern = @"^https?://", IsSystem = true, IsActive = true },
+        new() { LinkTypeId = 2, Name = "Torrent File", UrlPattern = @"\.torrent$", IsSystem = true, IsActive = true },
+        new() { LinkTypeId = 3, Name = "Magnet URI", UrlPattern = @"^magnet:\?", IsSystem = true, IsActive = true },
+        new() { LinkTypeId = 4, Name = "Cloud Storage URL", UrlPattern = @"(drive\.google|dropbox|mega\.nz)", IsSystem = true, IsActive = true }
+    };
+
+    public LinkExtractorServiceTests()
+    {
+        _linkTypeServiceMock
+            .Setup(s => s.GetActiveAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(DefaultLinkTypes);
+
+        // Default: classify HTTP URLs as type 1
+        _linkTypeServiceMock
+            .Setup(s => s.ClassifyUrl(It.Is<string>(u => u.StartsWith("http")), It.IsAny<IReadOnlyList<LinkType>>()))
+            .Returns(1);
+
+        // Magnet URIs as type 3
+        _linkTypeServiceMock
+            .Setup(s => s.ClassifyUrl(It.Is<string>(u => u.StartsWith("magnet:")), It.IsAny<IReadOnlyList<LinkType>>()))
+            .Returns(3);
+
+        _sut = new LinkExtractorService(_linkTypeServiceMock.Object, _loggerMock.Object);
+    }
+
+    // ── ExtractLinksAsync ────────────────────────────────────
+
+    [Fact]
+    public async Task ExtractLinksAsync_EmptyHtml_ReturnsEmpty()
+    {
+        var result = await _sut.ExtractLinksAsync("", 1, "https://forum.example.com/post/1");
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExtractLinksAsync_NullHtml_ReturnsEmpty()
+    {
+        var result = await _sut.ExtractLinksAsync(null!, 1, "https://forum.example.com/post/1");
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExtractLinksAsync_WhitespaceHtml_ReturnsEmpty()
+    {
+        var result = await _sut.ExtractLinksAsync("   ", 1, "https://forum.example.com/post/1");
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExtractLinksAsync_HtmlWithHttpLink_ExtractsLink()
+    {
+        var html = """<a href="https://example.com/file.zip">Download</a>""";
+
+        var result = await _sut.ExtractLinksAsync(html, 1, "https://forum.example.com/post/1");
+
+        result.Should().HaveCount(1);
+        result[0].Url.Should().Be("https://example.com/file.zip");
+        result[0].LinkTypeId.Should().Be(1);
+        result[0].RunId.Should().Be(1);
+        result[0].PostUrl.Should().Be("https://forum.example.com/post/1");
+        result[0].IsCurrent.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ExtractLinksAsync_MultipleLinks_ExtractsAll()
+    {
+        var html = """
+            <a href="https://example.com/file1.zip">File 1</a>
+            <a href="https://example.com/file2.zip">File 2</a>
+            """;
+
+        var result = await _sut.ExtractLinksAsync(html, 1, "https://forum.example.com/post/1");
+
+        result.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task ExtractLinksAsync_DuplicateUrls_DeduplicatesBeforeCreating()
+    {
+        var html = """
+            <a href="https://example.com/file.zip">Click</a>
+            <a href="https://example.com/file.zip">Click again</a>
+            """;
+
+        var result = await _sut.ExtractLinksAsync(html, 1, "https://forum.example.com/post/1");
+
+        result.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task ExtractLinksAsync_MagnetUri_ExtractsLink()
+    {
+        var html = """<a href="magnet:?xt=urn:btih:abc123">Magnet</a>""";
+
+        var result = await _sut.ExtractLinksAsync(html, 1, "https://forum.example.com/post/1");
+
+        result.Should().HaveCount(1);
+        result[0].Url.Should().StartWith("magnet:");
+        result[0].LinkTypeId.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task ExtractLinksAsync_JavascriptUrl_Stripped()
+    {
+        var html = """<a href="javascript:alert(1)">XSS</a>""";
+
+        var result = await _sut.ExtractLinksAsync(html, 1, "https://forum.example.com/post/1");
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExtractLinksAsync_DataUrl_Stripped()
+    {
+        var html = """<a href="data:text/html,<h1>Evil</h1>">Data</a>""";
+
+        var result = await _sut.ExtractLinksAsync(html, 1, "https://forum.example.com/post/1");
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExtractLinksAsync_UrlWithSeasonEpisode_ParsesCorrectly()
+    {
+        var html = """<a href="https://example.com/show-S02E05-720p.zip">Episode</a>""";
+
+        var result = await _sut.ExtractLinksAsync(html, 1, "https://forum.example.com/post/1");
+
+        result.Should().HaveCount(1);
+        result[0].ParsedSeason.Should().Be(2);
+        result[0].ParsedEpisode.Should().Be(5);
+    }
+
+    [Fact]
+    public async Task ExtractLinksAsync_UrlWithoutSeasonEpisode_NullValues()
+    {
+        var html = """<a href="https://dl.host.com/film-2024.zip">Movie</a>""";
+
+        var result = await _sut.ExtractLinksAsync(html, 1, "https://forum.example.com/post/1");
+
+        result.Should().HaveCount(1);
+        result[0].ParsedSeason.Should().BeNull();
+        result[0].ParsedEpisode.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ExtractLinksAsync_UnclassifiedUrl_SkipsLink()
+    {
+        _linkTypeServiceMock
+            .Setup(s => s.ClassifyUrl(It.IsAny<string>(), It.IsAny<IReadOnlyList<LinkType>>()))
+            .Returns((int?)null);
+
+        var html = """<a href="https://unmatched.example.com/file">Test</a>""";
+
+        var result = await _sut.ExtractLinksAsync(html, 1, "https://forum.example.com/post/1");
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExtractLinksAsync_PlainTextUrls_ExtractsFromText()
+    {
+        var html = "Download here: https://example.com/file.zip and enjoy";
+
+        var result = await _sut.ExtractLinksAsync(html, 1, "https://forum.example.com/post/1");
+
+        result.Should().HaveCount(1);
+        result[0].Url.Should().Be("https://example.com/file.zip");
+    }
+
+    [Fact]
+    public async Task ExtractLinksAsync_FtpScheme_Stripped()
+    {
+        var html = """<a href="ftp://example.com/file.zip">FTP</a>""";
+
+        var result = await _sut.ExtractLinksAsync(html, 1, "https://forum.example.com/post/1");
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExtractLinksAsync_SetsCreatedAtToUtcNow()
+    {
+        var html = """<a href="https://example.com/file.zip">Download</a>""";
+        var before = DateTime.UtcNow;
+
+        var result = await _sut.ExtractLinksAsync(html, 1, "https://forum.example.com/post/1");
+
+        var after = DateTime.UtcNow;
+        result[0].CreatedAt.Should().BeOnOrAfter(before).And.BeOnOrBefore(after);
+    }
+
+    // ── ExtractUrls (static) ─────────────────────────────────
+
+    [Fact]
+    public void ExtractUrls_HrefAndPlainText_ExtractsBoth()
+    {
+        var html = """<a href="https://a.com/1">Link</a> visit https://b.com/2""";
+
+        var result = LinkExtractorService.ExtractUrls(html);
+
+        result.Should().Contain("https://a.com/1");
+        result.Should().Contain("https://b.com/2");
+    }
+
+    [Fact]
+    public void ExtractUrls_EmptyHtml_ReturnsEmpty()
+    {
+        var result = LinkExtractorService.ExtractUrls("");
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ExtractUrls_SingleQuotedHref_Extracts()
+    {
+        var html = "<a href='https://example.com/file.zip'>Download</a>";
+
+        var result = LinkExtractorService.ExtractUrls(html);
+
+        result.Should().Contain("https://example.com/file.zip");
+    }
+
+    // ── IsAllowedScheme (static) ──────────────────────────────
+
+    [Theory]
+    [InlineData("https://example.com", true)]
+    [InlineData("http://example.com", true)]
+    [InlineData("magnet:?xt=urn:btih:abc", true)]
+    [InlineData("torrent://tracker.example.com", true)]
+    [InlineData("javascript:alert(1)", false)]
+    [InlineData("data:text/html,<h1>test</h1>", false)]
+    [InlineData("ftp://example.com/file", false)]
+    [InlineData("file:///etc/passwd", false)]
+    [InlineData("", false)]
+    public void IsAllowedScheme_VariousSchemes_ReturnsExpected(string url, bool expected)
+    {
+        LinkExtractorService.IsAllowedScheme(url).Should().Be(expected);
+    }
+
+    // ── ParseSeasonEpisode (static) ──────────────────────────
+
+    [Theory]
+    [InlineData("https://example.com/show-S01E05.zip", 1, 5)]
+    [InlineData("https://example.com/show-s12e03-720p", 12, 3)]
+    [InlineData("https://example.com/show-S1E1", 1, 1)]
+    public void ParseSeasonEpisode_FullPattern_ExtractsBoth(string url, int season, int episode)
+    {
+        var (s, e) = LinkExtractorService.ParseSeasonEpisode(url);
+
+        s.Should().Be(season);
+        e.Should().Be(episode);
+    }
+
+    [Fact]
+    public void ParseSeasonEpisode_SeasonOnly_ExtractsSeason()
+    {
+        var (s, e) = LinkExtractorService.ParseSeasonEpisode("https://example.com/show-Season3");
+
+        s.Should().Be(3);
+        e.Should().BeNull();
+    }
+
+    [Fact]
+    public void ParseSeasonEpisode_EpisodeOnly_ExtractsEpisode()
+    {
+        var (s, e) = LinkExtractorService.ParseSeasonEpisode("https://example.com/show-Episode10");
+
+        s.Should().BeNull();
+        e.Should().Be(10);
+    }
+
+    [Fact]
+    public void ParseSeasonEpisode_NeitherPattern_ReturnsNull()
+    {
+        var (s, e) = LinkExtractorService.ParseSeasonEpisode("https://dl.host.com/film-2024.zip");
+
+        s.Should().BeNull();
+        e.Should().BeNull();
+    }
+
+    [Fact]
+    public void ParseSeasonEpisode_EmptyUrl_ReturnsNull()
+    {
+        var (s, e) = LinkExtractorService.ParseSeasonEpisode("");
+
+        s.Should().BeNull();
+        e.Should().BeNull();
+    }
+}

--- a/tests/SeriesScraper.Infrastructure.Tests/Data/EntityCrudTests.cs
+++ b/tests/SeriesScraper.Infrastructure.Tests/Data/EntityCrudTests.cs
@@ -53,6 +53,7 @@ public class EntityCrudTests
         var link = new Link
         {
             Url = "https://download.example.com/file.zip",
+            PostUrl = "https://forum.example.com/post/1",
             LinkTypeId = linkType.LinkTypeId,
             RunId = run.RunId,
             CreatedAt = DateTime.UtcNow
@@ -87,6 +88,7 @@ public class EntityCrudTests
         var link = new Link
         {
             Url = "https://example.com/dl",
+            PostUrl = "https://forum.example.com/post/1",
             LinkTypeId = linkType.LinkTypeId,
             RunId = run.RunId,
             CreatedAt = DateTime.UtcNow
@@ -121,6 +123,7 @@ public class EntityCrudTests
         var movieLink = new Link
         {
             Url = "https://example.com/movie.mkv",
+            PostUrl = "https://forum.example.com/post/1",
             LinkTypeId = linkType.LinkTypeId,
             RunId = run.RunId,
             CreatedAt = DateTime.UtcNow
@@ -130,6 +133,7 @@ public class EntityCrudTests
         var seriesLink = new Link
         {
             Url = "https://example.com/show-s03e07.mkv",
+            PostUrl = "https://forum.example.com/post/1",
             LinkTypeId = linkType.LinkTypeId,
             RunId = run.RunId,
             ParsedSeason = 3,
@@ -170,6 +174,7 @@ public class EntityCrudTests
         var link = new Link
         {
             Url = "https://example.com/file.zip",
+            PostUrl = "https://forum.example.com/post/1",
             LinkTypeId = linkType.LinkTypeId,
             RunId = run.RunId,
             IsCurrent = true,
@@ -206,6 +211,7 @@ public class EntityCrudTests
         var link = new Link
         {
             Url = "https://example.com/delete-me",
+            PostUrl = "https://forum.example.com/post/1",
             LinkTypeId = linkType.LinkTypeId,
             RunId = run.RunId,
             CreatedAt = DateTime.UtcNow
@@ -240,6 +246,7 @@ public class EntityCrudTests
         var link = new Link
         {
             Url = "https://example.com/nav-test",
+            PostUrl = "https://forum.example.com/post/1",
             LinkTypeId = linkType.LinkTypeId,
             RunId = run.RunId,
             CreatedAt = DateTime.UtcNow
@@ -273,6 +280,7 @@ public class EntityCrudTests
         var link = new Link
         {
             Url = "https://example.com/run-nav",
+            PostUrl = "https://forum.example.com/post/1",
             LinkTypeId = linkType.LinkTypeId,
             RunId = run.RunId,
             CreatedAt = DateTime.UtcNow
@@ -500,8 +508,8 @@ public class EntityCrudTests
         context.SaveChanges();
 
         var linkType = context.LinkTypes.First();
-        context.Links.Add(new Link { Url = "https://example.com/a", LinkTypeId = linkType.LinkTypeId, RunId = run.RunId, CreatedAt = DateTime.UtcNow });
-        context.Links.Add(new Link { Url = "https://example.com/b", LinkTypeId = linkType.LinkTypeId, RunId = run.RunId, CreatedAt = DateTime.UtcNow });
+        context.Links.Add(new Link { Url = "https://example.com/a", PostUrl = "https://forum.example.com/post/1", LinkTypeId = linkType.LinkTypeId, RunId = run.RunId, CreatedAt = DateTime.UtcNow });
+        context.Links.Add(new Link { Url = "https://example.com/b", PostUrl = "https://forum.example.com/post/1", LinkTypeId = linkType.LinkTypeId, RunId = run.RunId, CreatedAt = DateTime.UtcNow });
         context.SaveChanges();
 
         var retrieved = context.ScrapeRuns.Include(r => r.Links).First(r => r.RunId == run.RunId);
@@ -938,8 +946,8 @@ public class EntityCrudTests
         context.SaveChanges();
 
         var linkType = context.LinkTypes.First();
-        context.Links.Add(new Link { Url = "https://example.com/lt-nav-1", LinkTypeId = linkType.LinkTypeId, RunId = run.RunId, CreatedAt = DateTime.UtcNow });
-        context.Links.Add(new Link { Url = "https://example.com/lt-nav-2", LinkTypeId = linkType.LinkTypeId, RunId = run.RunId, CreatedAt = DateTime.UtcNow });
+        context.Links.Add(new Link { Url = "https://example.com/lt-nav-1", PostUrl = "https://forum.example.com/post/1", LinkTypeId = linkType.LinkTypeId, RunId = run.RunId, CreatedAt = DateTime.UtcNow });
+        context.Links.Add(new Link { Url = "https://example.com/lt-nav-2", PostUrl = "https://forum.example.com/post/1", LinkTypeId = linkType.LinkTypeId, RunId = run.RunId, CreatedAt = DateTime.UtcNow });
         context.SaveChanges();
 
         var retrieved = context.LinkTypes.Include(lt => lt.Links).First(lt => lt.LinkTypeId == linkType.LinkTypeId);
@@ -978,6 +986,7 @@ public class EntityCrudTests
         var link = new Link
         {
             Url = "https://example.com",
+            PostUrl = "https://forum.example.com/post/1",
             LinkTypeId = 1,
             RunId = 1,
             IsCurrent = false,
@@ -1007,6 +1016,7 @@ public class EntityCrudTests
         var link = new Link
         {
             Url = "https://example.com/id-test",
+            PostUrl = "https://forum.example.com/post/1",
             LinkTypeId = linkType.LinkTypeId,
             RunId = run.RunId,
             CreatedAt = DateTime.UtcNow

--- a/tests/SeriesScraper.Infrastructure.Tests/Data/LinkRepositoryTests.cs
+++ b/tests/SeriesScraper.Infrastructure.Tests/Data/LinkRepositoryTests.cs
@@ -1,0 +1,238 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using SeriesScraper.Domain.Entities;
+using SeriesScraper.Domain.Enums;
+using SeriesScraper.Infrastructure.Data;
+
+namespace SeriesScraper.Infrastructure.Tests.Data;
+
+public class LinkRepositoryTests
+{
+    private static (AppDbContext Context, LinkRepository Repository) CreateSut()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        var context = new AppDbContext(options);
+        context.Database.EnsureCreated();
+        return (context, new LinkRepository(context));
+    }
+
+    private static async Task<(Forum Forum, ScrapeRun Run)> SeedForumAndRun(AppDbContext context)
+    {
+        var forum = new Forum
+        {
+            Name = "Test Forum",
+            BaseUrl = "https://forum.example.com",
+            Username = "testuser",
+            CredentialKey = "TEST_FORUM_PASSWORD"
+        };
+        context.Forums.Add(forum);
+        await context.SaveChangesAsync();
+
+        var run = new ScrapeRun
+        {
+            ForumId = forum.ForumId,
+            Status = ScrapeRunStatus.Running,
+            StartedAt = DateTime.UtcNow
+        };
+        context.ScrapeRuns.Add(run);
+        await context.SaveChangesAsync();
+
+        return (forum, run);
+    }
+
+    private static Link CreateLink(int runId, string postUrl, string url, bool isCurrent = true)
+    {
+        return new Link
+        {
+            Url = url,
+            PostUrl = postUrl,
+            LinkTypeId = 1, // Direct HTTP seed type
+            RunId = runId,
+            IsCurrent = isCurrent,
+            CreatedAt = DateTime.UtcNow
+        };
+    }
+
+    // ── GetCurrentByRunIdAsync ───────────────────────────────
+
+    [Fact]
+    public async Task GetCurrentByRunIdAsync_ReturnsOnlyCurrentLinks()
+    {
+        var (context, sut) = CreateSut();
+        using var _ = context;
+        var (_, run) = await SeedForumAndRun(context);
+
+        context.Links.AddRange(
+            CreateLink(run.RunId, "https://forum.example.com/post/1", "https://a.com/1"),
+            CreateLink(run.RunId, "https://forum.example.com/post/1", "https://a.com/2", isCurrent: false)
+        );
+        await context.SaveChangesAsync();
+
+        var result = await sut.GetCurrentByRunIdAsync(run.RunId);
+
+        result.Should().HaveCount(1);
+        result[0].Url.Should().Be("https://a.com/1");
+    }
+
+    [Fact]
+    public async Task GetCurrentByRunIdAsync_EmptyRun_ReturnsEmpty()
+    {
+        var (context, sut) = CreateSut();
+        using var _ = context;
+        var (_, run) = await SeedForumAndRun(context);
+
+        var result = await sut.GetCurrentByRunIdAsync(run.RunId);
+
+        result.Should().BeEmpty();
+    }
+
+    // ── GetCurrentByPostUrlAsync ─────────────────────────────
+
+    [Fact]
+    public async Task GetCurrentByPostUrlAsync_ReturnsMatchingPostOnly()
+    {
+        var (context, sut) = CreateSut();
+        using var _ = context;
+        var (_, run) = await SeedForumAndRun(context);
+
+        context.Links.AddRange(
+            CreateLink(run.RunId, "https://forum.example.com/post/1", "https://a.com/1"),
+            CreateLink(run.RunId, "https://forum.example.com/post/2", "https://b.com/2")
+        );
+        await context.SaveChangesAsync();
+
+        var result = await sut.GetCurrentByPostUrlAsync("https://forum.example.com/post/1", run.RunId);
+
+        result.Should().HaveCount(1);
+        result[0].Url.Should().Be("https://a.com/1");
+    }
+
+    // ── AddRangeAsync ────────────────────────────────────────
+
+    [Fact]
+    public async Task AddRangeAsync_InsertsLinks()
+    {
+        var (context, sut) = CreateSut();
+        using var _ = context;
+        var (_, run) = await SeedForumAndRun(context);
+
+        var links = new[]
+        {
+            CreateLink(run.RunId, "https://forum.example.com/post/1", "https://a.com/1"),
+            CreateLink(run.RunId, "https://forum.example.com/post/1", "https://a.com/2")
+        };
+
+        await sut.AddRangeAsync(links);
+
+        var count = await context.Links.CountAsync();
+        count.Should().Be(2);
+    }
+
+    // ── MarkPreviousAsNonCurrentAsync ────────────────────────
+
+    [Fact]
+    public async Task MarkPreviousAsNonCurrentAsync_MarksCorrectLinksOnly()
+    {
+        var (context, sut) = CreateSut();
+        using var _ = context;
+        var (_, run) = await SeedForumAndRun(context);
+
+        context.Links.AddRange(
+            CreateLink(run.RunId, "https://forum.example.com/post/1", "https://a.com/1"),
+            CreateLink(run.RunId, "https://forum.example.com/post/2", "https://b.com/1")
+        );
+        await context.SaveChangesAsync();
+
+        await sut.MarkPreviousAsNonCurrentAsync(run.RunId, "https://forum.example.com/post/1");
+
+        var post1Links = await context.Links
+            .Where(l => l.PostUrl == "https://forum.example.com/post/1")
+            .ToListAsync();
+        var post2Links = await context.Links
+            .Where(l => l.PostUrl == "https://forum.example.com/post/2")
+            .ToListAsync();
+
+        post1Links.Should().AllSatisfy(l => l.IsCurrent.Should().BeFalse());
+        post2Links.Should().AllSatisfy(l => l.IsCurrent.Should().BeTrue());
+    }
+
+    // ── AccumulateLinksAsync ─────────────────────────────────
+
+    [Fact]
+    public async Task AccumulateLinksAsync_MarksOldAsNonCurrent_InsertsNew()
+    {
+        var (context, sut) = CreateSut();
+        using var _ = context;
+        var (_, run) = await SeedForumAndRun(context);
+
+        // Insert original links
+        context.Links.Add(CreateLink(run.RunId, "https://forum.example.com/post/1", "https://old.com/1"));
+        await context.SaveChangesAsync();
+
+        // Accumulate new links
+        var newLinks = new[]
+        {
+            CreateLink(run.RunId, "https://forum.example.com/post/1", "https://new.com/1"),
+            CreateLink(run.RunId, "https://forum.example.com/post/1", "https://new.com/2")
+        };
+
+        await sut.AccumulateLinksAsync(run.RunId, "https://forum.example.com/post/1", newLinks);
+
+        var allLinks = await context.Links.ToListAsync();
+        allLinks.Should().HaveCount(3);
+
+        var oldLink = allLinks.Single(l => l.Url == "https://old.com/1");
+        oldLink.IsCurrent.Should().BeFalse();
+
+        var currentLinks = allLinks.Where(l => l.IsCurrent).ToList();
+        currentLinks.Should().HaveCount(2);
+        currentLinks.Select(l => l.Url).Should().Contain("https://new.com/1");
+        currentLinks.Select(l => l.Url).Should().Contain("https://new.com/2");
+    }
+
+    [Fact]
+    public async Task AccumulateLinksAsync_NoExistingLinks_InsertsNew()
+    {
+        var (context, sut) = CreateSut();
+        using var _ = context;
+        var (_, run) = await SeedForumAndRun(context);
+
+        var newLinks = new[]
+        {
+            CreateLink(run.RunId, "https://forum.example.com/post/1", "https://new.com/1")
+        };
+
+        await sut.AccumulateLinksAsync(run.RunId, "https://forum.example.com/post/1", newLinks);
+
+        var allLinks = await context.Links.ToListAsync();
+        allLinks.Should().HaveCount(1);
+        allLinks[0].IsCurrent.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task AccumulateLinksAsync_DoesNotAffectOtherPosts()
+    {
+        var (context, sut) = CreateSut();
+        using var _ = context;
+        var (_, run) = await SeedForumAndRun(context);
+
+        // Link for post/2 should remain current
+        context.Links.Add(CreateLink(run.RunId, "https://forum.example.com/post/2", "https://other.com/1"));
+        await context.SaveChangesAsync();
+
+        var newLinks = new[]
+        {
+            CreateLink(run.RunId, "https://forum.example.com/post/1", "https://new.com/1")
+        };
+
+        await sut.AccumulateLinksAsync(run.RunId, "https://forum.example.com/post/1", newLinks);
+
+        var otherPostLinks = await context.Links
+            .Where(l => l.PostUrl == "https://forum.example.com/post/2")
+            .ToListAsync();
+        otherPostLinks.Should().AllSatisfy(l => l.IsCurrent.Should().BeTrue());
+    }
+}

--- a/tests/SeriesScraper.Infrastructure.Tests/Data/MediaEpisodeRepositoryTests.cs
+++ b/tests/SeriesScraper.Infrastructure.Tests/Data/MediaEpisodeRepositoryTests.cs
@@ -1,0 +1,147 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using SeriesScraper.Domain.Entities;
+using SeriesScraper.Domain.Enums;
+using SeriesScraper.Infrastructure.Data;
+
+namespace SeriesScraper.Infrastructure.Tests.Data;
+
+public class MediaEpisodeRepositoryTests
+{
+    private static (AppDbContext Context, MediaEpisodeRepository Repository) CreateSut()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        var context = new AppDbContext(options);
+        context.Database.EnsureCreated();
+        return (context, new MediaEpisodeRepository(context));
+    }
+
+    private static async Task<MediaTitle> SeedMediaTitle(AppDbContext context)
+    {
+        // DataSource is seeded by EnsureCreated (seed data: SourceId=1, Name="IMDB")
+        // Use the seed SourceId directly
+        var sourceId = 1;
+
+        var title = new MediaTitle
+        {
+            CanonicalTitle = "Test Series",
+            Year = 2024,
+            Type = MediaType.Series,
+            SourceId = sourceId,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+        context.MediaTitles.Add(title);
+        await context.SaveChangesAsync();
+
+        return title;
+    }
+
+    // ── GetByMediaIdAsync ────────────────────────────────────
+
+    [Fact]
+    public async Task GetByMediaIdAsync_ReturnsEpisodesOrderedBySeasonAndNumber()
+    {
+        var (context, sut) = CreateSut();
+        using var _ = context;
+        var title = await SeedMediaTitle(context);
+
+        context.MediaEpisodes.AddRange(
+            new MediaEpisode { MediaId = title.MediaId, Season = 1, EpisodeNumber = 2 },
+            new MediaEpisode { MediaId = title.MediaId, Season = 1, EpisodeNumber = 1 },
+            new MediaEpisode { MediaId = title.MediaId, Season = 2, EpisodeNumber = 1 }
+        );
+        await context.SaveChangesAsync();
+
+        var result = await sut.GetByMediaIdAsync(title.MediaId);
+
+        result.Should().HaveCount(3);
+        result[0].Season.Should().Be(1);
+        result[0].EpisodeNumber.Should().Be(1);
+        result[1].Season.Should().Be(1);
+        result[1].EpisodeNumber.Should().Be(2);
+        result[2].Season.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task GetByMediaIdAsync_NoEpisodes_ReturnsEmpty()
+    {
+        var (context, sut) = CreateSut();
+        using var _ = context;
+        var title = await SeedMediaTitle(context);
+
+        var result = await sut.GetByMediaIdAsync(title.MediaId);
+
+        result.Should().BeEmpty();
+    }
+
+    // ── GetEpisodeCountForSeasonAsync ────────────────────────
+
+    [Fact]
+    public async Task GetEpisodeCountForSeasonAsync_ReturnsCorrectCount()
+    {
+        var (context, sut) = CreateSut();
+        using var _ = context;
+        var title = await SeedMediaTitle(context);
+
+        context.MediaEpisodes.AddRange(
+            new MediaEpisode { MediaId = title.MediaId, Season = 1, EpisodeNumber = 1 },
+            new MediaEpisode { MediaId = title.MediaId, Season = 1, EpisodeNumber = 2 },
+            new MediaEpisode { MediaId = title.MediaId, Season = 2, EpisodeNumber = 1 }
+        );
+        await context.SaveChangesAsync();
+
+        var count = await sut.GetEpisodeCountForSeasonAsync(title.MediaId, 1);
+
+        count.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task GetEpisodeCountForSeasonAsync_NoEpisodes_ReturnsZero()
+    {
+        var (context, sut) = CreateSut();
+        using var _ = context;
+        var title = await SeedMediaTitle(context);
+
+        var count = await sut.GetEpisodeCountForSeasonAsync(title.MediaId, 1);
+
+        count.Should().Be(0);
+    }
+
+    // ── GetSeasonsAsync ──────────────────────────────────────
+
+    [Fact]
+    public async Task GetSeasonsAsync_ReturnsDistinctSeasonsOrdered()
+    {
+        var (context, sut) = CreateSut();
+        using var _ = context;
+        var title = await SeedMediaTitle(context);
+
+        context.MediaEpisodes.AddRange(
+            new MediaEpisode { MediaId = title.MediaId, Season = 3, EpisodeNumber = 1 },
+            new MediaEpisode { MediaId = title.MediaId, Season = 1, EpisodeNumber = 1 },
+            new MediaEpisode { MediaId = title.MediaId, Season = 1, EpisodeNumber = 2 },
+            new MediaEpisode { MediaId = title.MediaId, Season = 2, EpisodeNumber = 1 }
+        );
+        await context.SaveChangesAsync();
+
+        var result = await sut.GetSeasonsAsync(title.MediaId);
+
+        result.Should().BeEquivalentTo(new[] { 1, 2, 3 }, options => options.WithStrictOrdering());
+    }
+
+    [Fact]
+    public async Task GetSeasonsAsync_NoEpisodes_ReturnsEmpty()
+    {
+        var (context, sut) = CreateSut();
+        using var _ = context;
+        var title = await SeedMediaTitle(context);
+
+        var result = await sut.GetSeasonsAsync(title.MediaId);
+
+        result.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

Implements link extraction from post HTML, URL scheme validation, season/episode parsing, TV series completeness checking against IMDB episode counts, and the accumulate-with-flag re-scrape pattern.

Closes #29

## Changes

### Domain Layer
- **CompletenessStatus** enum: Complete, Incomplete, Unknown
- **ILinkRepository**: repository contract for Link CRUD and accumulate-with-flag pattern
- **IMediaEpisodeRepository**: queries for episode counts and seasons
- **ILinkExtractorService**: service contract for link extraction from HTML
- **ICompletenessCheckerService**: service contract for completeness checking
- **Link.PostUrl** (new required property): scopes the accumulate-with-flag pattern per post

### Application Layer
- **LinkExtractorService**: extracts URLs from href attributes and plain text, classifies by LinkType regex, parses S01E02/Season/Episode patterns from URLs, strips javascript:/data:/ftp: schemes (AC#5)
- **CompletenessCheckerService**: movies complete with >=1 link (AC#4), TV series checks distinct episode count per season against MediaEpisodes (AC#3), archive links (no episode number) treated as Complete heuristic
- InternalsVisibleTo for Application test project

### Infrastructure Layer
- **LinkRepository**: GetCurrentByRunIdAsync, GetCurrentByPostUrlAsync, AddRangeAsync, MarkPreviousAsNonCurrentAsync, AccumulateLinksAsync (atomic mark-old + insert-new via single SaveChangesAsync)
- **MediaEpisodeRepository**: GetByMediaIdAsync, GetEpisodeCountForSeasonAsync, GetSeasonsAsync
- **LinkConfiguration** updated: composite index on (RunId, PostUrl, IsCurrent)

### Tests (61 new, all passing)
- LinkExtractorServiceTests (34): URL extraction, scheme filtering, season/episode parsing, deduplication, classification, edge cases
- CompletenessCheckerServiceTests (13): movies, series complete/incomplete/unknown, multi-season, archive heuristic, duplicate episode links
- LinkRepositoryTests (8): CRUD, accumulate-with-flag, post scoping
- MediaEpisodeRepositoryTests (6): episode queries, ordering, empty cases
- Existing EntityCrudTests updated for new PostUrl required property

## Testing Notes
- 440 total tests pass (61 new + 379 existing)
- All new code tested via unit tests with Moq (Application) and InMemory provider (Infrastructure)

## AC Coverage
| AC | Status | Notes |
|----|--------|-------|
| 1 | Done | Link entity with all specified columns + PostUrl for scoping |
| 2 | Done | Season/episode regex parsing, nullable integers, failure = null |
| 3 | Done | TV completeness: distinct episodes vs MediaEpisodes count |
| 4 | Done | Movie: >=1 link = Complete |
| 5 | Done | Only http/https/magnet/torrent; javascript/data stripped |
| 6 | Deferred | UI Copy all links button - requires Blazor UI layer (separate issue) |
| 7 | Done | Accumulate-with-flag: atomic mark non-current + insert new |

## Known Limitations
- AC#6 (Copy all links UI button) deferred - requires Blazor component work in Results UI epic
- DI registration not included (wired in composition root per Web project conventions)