### PR TITLE
feat(#23): IMDB matching engine

### DIFF
--- a/src/SeriesScraper.Application/Services/ImdbMatchingService.cs
+++ b/src/SeriesScraper.Application/Services/ImdbMatchingService.cs
@@ -1,0 +1,80 @@
+using Microsoft.Extensions.Logging;
+using SeriesScraper.Domain.Interfaces;
+using SeriesScraper.Domain.ValueObjects;
+
+namespace SeriesScraper.Application.Services;
+
+/// <summary>
+/// Orchestrates IMDB title matching for scraped forum content.
+/// Parses scraped title strings, extracts embedded years, delegates to
+/// IMetadataSource for actual search, and handles disambiguation.
+/// </summary>
+public class ImdbMatchingService : IImdbMatchingService
+{
+    private const decimal MinimumConfidenceThreshold = 0.5m;
+
+    private readonly IMetadataSource _metadataSource;
+    private readonly ITitleNormalizer _normalizer;
+    private readonly ILogger<ImdbMatchingService> _logger;
+
+    public ImdbMatchingService(
+        IMetadataSource metadataSource,
+        ITitleNormalizer normalizer,
+        ILogger<ImdbMatchingService> logger)
+    {
+        _metadataSource = metadataSource ?? throw new ArgumentNullException(nameof(metadataSource));
+        _normalizer = normalizer ?? throw new ArgumentNullException(nameof(normalizer));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<MetadataSearchResult?> FindBestMatchAsync(
+        string scrapedTitle,
+        string? type = null,
+        CancellationToken cancellationToken = default)
+    {
+        var matches = await FindMatchesAsync(scrapedTitle, type, cancellationToken);
+
+        var best = matches.FirstOrDefault();
+        if (best is null || best.ConfidenceScore < MinimumConfidenceThreshold)
+        {
+            _logger.LogDebug(
+                "No match above threshold {Threshold} for scraped title '{Title}'",
+                MinimumConfidenceThreshold, scrapedTitle);
+            return null;
+        }
+
+        _logger.LogDebug(
+            "Best match for '{Title}': {CanonicalTitle} (confidence={Confidence}, externalId={ExternalId})",
+            scrapedTitle, best.CanonicalTitle, best.ConfidenceScore, best.ExternalId);
+
+        return best;
+    }
+
+    public async Task<IReadOnlyList<MetadataSearchResult>> FindMatchesAsync(
+        string scrapedTitle,
+        string? type = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(scrapedTitle))
+            return Array.Empty<MetadataSearchResult>();
+
+        // Extract embedded year from title (e.g. "Breaking Bad (2008)")
+        var year = _normalizer.ExtractYear(scrapedTitle);
+        var cleanTitle = _normalizer.StripYear(scrapedTitle);
+
+        if (string.IsNullOrWhiteSpace(cleanTitle))
+            return Array.Empty<MetadataSearchResult>();
+
+        _logger.LogDebug(
+            "Matching scraped title '{Original}' → cleaned='{Clean}', year={Year}, type={Type}",
+            scrapedTitle, cleanTitle, year, type);
+
+        var results = await _metadataSource.SearchByTitleAsync(cleanTitle, year, type, cancellationToken);
+
+        _logger.LogDebug(
+            "Found {Count} matches for '{Title}'",
+            results.Count, scrapedTitle);
+
+        return results;
+    }
+}

--- a/src/SeriesScraper.Application/Services/TitleNormalizer.cs
+++ b/src/SeriesScraper.Application/Services/TitleNormalizer.cs
@@ -1,0 +1,117 @@
+using System.Globalization;
+using System.Text;
+using System.Text.RegularExpressions;
+using SeriesScraper.Domain.Interfaces;
+
+namespace SeriesScraper.Application.Services;
+
+/// <summary>
+/// Normalizes media titles for matching: strips diacritics, removes punctuation,
+/// extracts embedded years, and computes Levenshtein-based similarity scores.
+/// </summary>
+public class TitleNormalizer : ITitleNormalizer
+{
+    private static readonly Regex YearPattern = new(@"\((\d{4})\)", RegexOptions.Compiled);
+    private static readonly Regex YearStripPattern = new(@"\s*\(\d{4}\)\s*", RegexOptions.Compiled);
+    private static readonly Regex NonAlphanumericPattern = new(@"[^\p{L}\p{N}\s]", RegexOptions.Compiled);
+    private static readonly Regex WhitespacePattern = new(@"\s+", RegexOptions.Compiled);
+
+    public string Normalize(string title)
+    {
+        if (string.IsNullOrWhiteSpace(title))
+            return string.Empty;
+
+        var stripped = StripYear(title);
+        var noDiacritics = RemoveDiacritics(stripped);
+        var lower = noDiacritics.ToLowerInvariant();
+        var noPunctuation = NonAlphanumericPattern.Replace(lower, "");
+        var collapsed = WhitespacePattern.Replace(noPunctuation, " ").Trim();
+
+        return collapsed;
+    }
+
+    public int? ExtractYear(string title)
+    {
+        if (string.IsNullOrWhiteSpace(title))
+            return null;
+
+        var match = YearPattern.Match(title);
+        if (match.Success && int.TryParse(match.Groups[1].Value, out var year))
+            return year;
+
+        return null;
+    }
+
+    public string StripYear(string title)
+    {
+        if (string.IsNullOrWhiteSpace(title))
+            return string.Empty;
+
+        return YearStripPattern.Replace(title, " ").Trim();
+    }
+
+    public decimal ComputeSimilarity(string a, string b)
+    {
+        if (string.IsNullOrEmpty(a) && string.IsNullOrEmpty(b))
+            return 1.0m;
+        if (string.IsNullOrEmpty(a) || string.IsNullOrEmpty(b))
+            return 0.0m;
+
+        var na = Normalize(a);
+        var nb = Normalize(b);
+
+        if (na.Length == 0 && nb.Length == 0)
+            return 1.0m;
+        if (na.Length == 0 || nb.Length == 0)
+            return 0.0m;
+
+        if (na == nb)
+            return 1.0m;
+
+        var distance = LevenshteinDistance(na, nb);
+        var maxLen = Math.Max(na.Length, nb.Length);
+
+        return 1.0m - (decimal)distance / maxLen;
+    }
+
+    internal static string RemoveDiacritics(string text)
+    {
+        var normalized = text.Normalize(NormalizationForm.FormD);
+        var sb = new StringBuilder(normalized.Length);
+
+        foreach (var c in normalized)
+        {
+            if (CharUnicodeInfo.GetUnicodeCategory(c) != UnicodeCategory.NonSpacingMark)
+                sb.Append(c);
+        }
+
+        return sb.ToString().Normalize(NormalizationForm.FormC);
+    }
+
+    internal static int LevenshteinDistance(string a, string b)
+    {
+        if (a.Length == 0) return b.Length;
+        if (b.Length == 0) return a.Length;
+
+        var costs = new int[b.Length + 1];
+        for (var j = 0; j <= b.Length; j++)
+            costs[j] = j;
+
+        for (var i = 1; i <= a.Length; i++)
+        {
+            costs[0] = i;
+            var prev = i - 1;
+
+            for (var j = 1; j <= b.Length; j++)
+            {
+                var temp = costs[j];
+                costs[j] = a[i - 1] == b[j - 1]
+                    ? prev
+                    : Math.Min(Math.Min(costs[j] + 1, costs[j - 1] + 1), prev + 1);
+                prev = temp;
+            }
+        }
+
+        return costs[b.Length];
+    }
+}

--- a/src/SeriesScraper.Domain/Interfaces/IImdbMatchingService.cs
+++ b/src/SeriesScraper.Domain/Interfaces/IImdbMatchingService.cs
@@ -1,0 +1,29 @@
+using SeriesScraper.Domain.ValueObjects;
+
+namespace SeriesScraper.Domain.Interfaces;
+
+/// <summary>
+/// High-level service for matching scraped forum content against IMDB data.
+/// Handles title parsing, year extraction, and disambiguation.
+/// </summary>
+public interface IImdbMatchingService
+{
+    /// <summary>
+    /// Finds the single best IMDB match for a scraped title string.
+    /// Automatically extracts embedded year from the title.
+    /// Returns null if no match above the minimum confidence threshold.
+    /// </summary>
+    Task<MetadataSearchResult?> FindBestMatchAsync(
+        string scrapedTitle,
+        string? type = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Finds all potential IMDB matches for a scraped title, ranked by confidence.
+    /// Automatically extracts embedded year from the title.
+    /// </summary>
+    Task<IReadOnlyList<MetadataSearchResult>> FindMatchesAsync(
+        string scrapedTitle,
+        string? type = null,
+        CancellationToken cancellationToken = default);
+}

--- a/src/SeriesScraper.Domain/Interfaces/IImdbTitleDetailsRepository.cs
+++ b/src/SeriesScraper.Domain/Interfaces/IImdbTitleDetailsRepository.cs
@@ -1,0 +1,25 @@
+using SeriesScraper.Domain.Entities;
+
+namespace SeriesScraper.Domain.Interfaces;
+
+/// <summary>
+/// Repository for IMDB-specific title details (tconst, genres).
+/// </summary>
+public interface IImdbTitleDetailsRepository
+{
+    /// <summary>
+    /// Looks up IMDB title details by tconst (e.g. "tt0133093").
+    /// </summary>
+    Task<ImdbTitleDetails?> GetByTconstAsync(string tconst, CancellationToken ct = default);
+
+    /// <summary>
+    /// Looks up IMDB title details by canonical media ID.
+    /// </summary>
+    Task<ImdbTitleDetails?> GetByMediaIdAsync(int mediaId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Batch-loads IMDB details for multiple media IDs.
+    /// </summary>
+    Task<IReadOnlyDictionary<int, ImdbTitleDetails>> GetByMediaIdsAsync(
+        IReadOnlyList<int> mediaIds, CancellationToken ct = default);
+}

--- a/src/SeriesScraper.Domain/Interfaces/IMediaRatingRepository.cs
+++ b/src/SeriesScraper.Domain/Interfaces/IMediaRatingRepository.cs
@@ -1,0 +1,14 @@
+using SeriesScraper.Domain.Entities;
+
+namespace SeriesScraper.Domain.Interfaces;
+
+/// <summary>
+/// Repository for retrieving media ratings by source.
+/// </summary>
+public interface IMediaRatingRepository
+{
+    /// <summary>
+    /// Gets the rating for a media title from a specific data source.
+    /// </summary>
+    Task<MediaRating?> GetByMediaIdAndSourceAsync(int mediaId, int sourceId, CancellationToken ct = default);
+}

--- a/src/SeriesScraper.Domain/Interfaces/IMediaTitleRepository.cs
+++ b/src/SeriesScraper.Domain/Interfaces/IMediaTitleRepository.cs
@@ -1,0 +1,37 @@
+using SeriesScraper.Domain.Entities;
+using SeriesScraper.Domain.Enums;
+
+namespace SeriesScraper.Domain.Interfaces;
+
+/// <summary>
+/// Repository for searching media titles and aliases.
+/// Used by the IMDB matching engine for candidate retrieval.
+/// </summary>
+public interface IMediaTitleRepository
+{
+    /// <summary>
+    /// Searches canonical titles using case-insensitive containment.
+    /// </summary>
+    Task<IReadOnlyList<MediaTitle>> SearchByTitleAsync(
+        string normalizedSearchTerm,
+        MediaType? type = null,
+        int? year = null,
+        int maxResults = 100,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Searches alias titles using case-insensitive containment.
+    /// Includes the parent MediaTitle for type/year filtering.
+    /// </summary>
+    Task<IReadOnlyList<MediaTitleAlias>> SearchByAliasAsync(
+        string normalizedSearchTerm,
+        MediaType? type = null,
+        int? year = null,
+        int maxResults = 100,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets a single media title by its canonical ID.
+    /// </summary>
+    Task<MediaTitle?> GetByIdAsync(int mediaId, CancellationToken ct = default);
+}

--- a/src/SeriesScraper.Domain/Interfaces/ITitleNormalizer.cs
+++ b/src/SeriesScraper.Domain/Interfaces/ITitleNormalizer.cs
@@ -1,0 +1,30 @@
+namespace SeriesScraper.Domain.Interfaces;
+
+/// <summary>
+/// Normalizes media titles for matching and comparison.
+/// Handles diacritics removal, year extraction, and fuzzy similarity scoring.
+/// </summary>
+public interface ITitleNormalizer
+{
+    /// <summary>
+    /// Normalizes a title: lowercase, strip diacritics, remove punctuation, collapse whitespace.
+    /// </summary>
+    string Normalize(string title);
+
+    /// <summary>
+    /// Extracts a four-digit year from parenthesized suffix, e.g. "Movie Name (2024)" → 2024.
+    /// Returns null if no year found.
+    /// </summary>
+    int? ExtractYear(string title);
+
+    /// <summary>
+    /// Removes the parenthesized year suffix from a title string.
+    /// </summary>
+    string StripYear(string title);
+
+    /// <summary>
+    /// Computes normalized similarity between two titles (0.0 = completely different, 1.0 = identical).
+    /// Both inputs are normalized before comparison.
+    /// </summary>
+    decimal ComputeSimilarity(string a, string b);
+}

--- a/src/SeriesScraper.Infrastructure/Data/ImdbTitleDetailsRepository.cs
+++ b/src/SeriesScraper.Infrastructure/Data/ImdbTitleDetailsRepository.cs
@@ -1,0 +1,44 @@
+using Microsoft.EntityFrameworkCore;
+using SeriesScraper.Domain.Entities;
+using SeriesScraper.Domain.Interfaces;
+
+namespace SeriesScraper.Infrastructure.Data;
+
+public class ImdbTitleDetailsRepository : IImdbTitleDetailsRepository
+{
+    private readonly AppDbContext _context;
+
+    public ImdbTitleDetailsRepository(AppDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<ImdbTitleDetails?> GetByTconstAsync(string tconst, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(tconst))
+            return null;
+
+        return await _context.ImdbTitleDetails
+            .AsNoTracking()
+            .FirstOrDefaultAsync(d => d.Tconst == tconst, ct);
+    }
+
+    public async Task<ImdbTitleDetails?> GetByMediaIdAsync(int mediaId, CancellationToken ct = default)
+    {
+        return await _context.ImdbTitleDetails
+            .AsNoTracking()
+            .FirstOrDefaultAsync(d => d.MediaId == mediaId, ct);
+    }
+
+    public async Task<IReadOnlyDictionary<int, ImdbTitleDetails>> GetByMediaIdsAsync(
+        IReadOnlyList<int> mediaIds, CancellationToken ct = default)
+    {
+        if (mediaIds.Count == 0)
+            return new Dictionary<int, ImdbTitleDetails>();
+
+        return await _context.ImdbTitleDetails
+            .Where(d => mediaIds.Contains(d.MediaId))
+            .AsNoTracking()
+            .ToDictionaryAsync(d => d.MediaId, ct);
+    }
+}

--- a/src/SeriesScraper.Infrastructure/Data/MediaRatingRepository.cs
+++ b/src/SeriesScraper.Infrastructure/Data/MediaRatingRepository.cs
@@ -1,0 +1,23 @@
+using Microsoft.EntityFrameworkCore;
+using SeriesScraper.Domain.Entities;
+using SeriesScraper.Domain.Interfaces;
+
+namespace SeriesScraper.Infrastructure.Data;
+
+public class MediaRatingRepository : IMediaRatingRepository
+{
+    private readonly AppDbContext _context;
+
+    public MediaRatingRepository(AppDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<MediaRating?> GetByMediaIdAndSourceAsync(
+        int mediaId, int sourceId, CancellationToken ct = default)
+    {
+        return await _context.MediaRatings
+            .AsNoTracking()
+            .FirstOrDefaultAsync(r => r.MediaId == mediaId && r.SourceId == sourceId, ct);
+    }
+}

--- a/src/SeriesScraper.Infrastructure/Data/MediaTitleRepository.cs
+++ b/src/SeriesScraper.Infrastructure/Data/MediaTitleRepository.cs
@@ -1,0 +1,81 @@
+using Microsoft.EntityFrameworkCore;
+using SeriesScraper.Domain.Entities;
+using SeriesScraper.Domain.Enums;
+using SeriesScraper.Domain.Interfaces;
+
+namespace SeriesScraper.Infrastructure.Data;
+
+public class MediaTitleRepository : IMediaTitleRepository
+{
+    private readonly AppDbContext _context;
+
+    public MediaTitleRepository(AppDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<IReadOnlyList<MediaTitle>> SearchByTitleAsync(
+        string normalizedSearchTerm,
+        MediaType? type = null,
+        int? year = null,
+        int maxResults = 100,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(normalizedSearchTerm))
+            return Array.Empty<MediaTitle>();
+
+        var lowerTerm = normalizedSearchTerm.ToLowerInvariant();
+
+        var query = _context.MediaTitles.AsQueryable();
+
+        query = query.Where(t => t.CanonicalTitle.ToLower().Contains(lowerTerm));
+
+        if (type.HasValue)
+            query = query.Where(t => t.Type == type.Value);
+
+        if (year.HasValue)
+            query = query.Where(t => t.Year == year.Value);
+
+        return await query
+            .OrderBy(t => t.CanonicalTitle)
+            .Take(maxResults)
+            .AsNoTracking()
+            .ToListAsync(ct);
+    }
+
+    public async Task<IReadOnlyList<MediaTitleAlias>> SearchByAliasAsync(
+        string normalizedSearchTerm,
+        MediaType? type = null,
+        int? year = null,
+        int maxResults = 100,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(normalizedSearchTerm))
+            return Array.Empty<MediaTitleAlias>();
+
+        var lowerTerm = normalizedSearchTerm.ToLowerInvariant();
+
+        var query = _context.MediaTitleAliases
+            .Include(a => a.MediaTitle)
+            .Where(a => a.AliasTitle.ToLower().Contains(lowerTerm));
+
+        if (type.HasValue)
+            query = query.Where(a => a.MediaTitle.Type == type.Value);
+
+        if (year.HasValue)
+            query = query.Where(a => a.MediaTitle.Year == year.Value);
+
+        return await query
+            .OrderBy(a => a.AliasTitle)
+            .Take(maxResults)
+            .AsNoTracking()
+            .ToListAsync(ct);
+    }
+
+    public async Task<MediaTitle?> GetByIdAsync(int mediaId, CancellationToken ct = default)
+    {
+        return await _context.MediaTitles
+            .AsNoTracking()
+            .FirstOrDefaultAsync(t => t.MediaId == mediaId, ct);
+    }
+}

--- a/src/SeriesScraper.Infrastructure/Services/Imdb/ImdbMetadataSource.cs
+++ b/src/SeriesScraper.Infrastructure/Services/Imdb/ImdbMetadataSource.cs
@@ -1,0 +1,229 @@
+using Microsoft.Extensions.Logging;
+using SeriesScraper.Domain.Entities;
+using SeriesScraper.Domain.Enums;
+using SeriesScraper.Domain.Interfaces;
+using SeriesScraper.Domain.ValueObjects;
+
+namespace SeriesScraper.Infrastructure.Services.Imdb;
+
+/// <summary>
+/// IMDB implementation of IMetadataSource.
+/// Searches imported IMDB data (MediaTitle, MediaTitleAlias, ImdbTitleDetails)
+/// using fuzzy/normalized string matching with confidence scoring.
+/// </summary>
+public class ImdbMetadataSource : IMetadataSource
+{
+    public const int ImdbSourceId = 1;
+    public const int MaxCandidates = 100;
+    public const decimal AliasPenalty = 0.02m;
+    public const decimal YearBonus = 0.05m;
+
+    private readonly IMediaTitleRepository _titleRepo;
+    private readonly IMediaEpisodeRepository _episodeRepo;
+    private readonly IMediaRatingRepository _ratingRepo;
+    private readonly IImdbTitleDetailsRepository _imdbDetailsRepo;
+    private readonly ITitleNormalizer _normalizer;
+    private readonly ILogger<ImdbMetadataSource> _logger;
+
+    public ImdbMetadataSource(
+        IMediaTitleRepository titleRepo,
+        IMediaEpisodeRepository episodeRepo,
+        IMediaRatingRepository ratingRepo,
+        IImdbTitleDetailsRepository imdbDetailsRepo,
+        ITitleNormalizer normalizer,
+        ILogger<ImdbMetadataSource> logger)
+    {
+        _titleRepo = titleRepo ?? throw new ArgumentNullException(nameof(titleRepo));
+        _episodeRepo = episodeRepo ?? throw new ArgumentNullException(nameof(episodeRepo));
+        _ratingRepo = ratingRepo ?? throw new ArgumentNullException(nameof(ratingRepo));
+        _imdbDetailsRepo = imdbDetailsRepo ?? throw new ArgumentNullException(nameof(imdbDetailsRepo));
+        _normalizer = normalizer ?? throw new ArgumentNullException(nameof(normalizer));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public string SourceIdentifier => "imdb";
+
+    public async Task<IReadOnlyList<MetadataSearchResult>> SearchByTitleAsync(
+        string query,
+        int? year = null,
+        string? type = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(query))
+            return Array.Empty<MetadataSearchResult>();
+
+        var normalizedQuery = _normalizer.Normalize(query);
+        if (string.IsNullOrEmpty(normalizedQuery))
+            return Array.Empty<MetadataSearchResult>();
+
+        var mediaType = ParseMediaType(type);
+
+        // Get candidates from canonical titles
+        var titleCandidates = await _titleRepo.SearchByTitleAsync(
+            normalizedQuery, mediaType, year, MaxCandidates, cancellationToken);
+
+        // Get candidates from aliases
+        var aliasCandidates = await _titleRepo.SearchByAliasAsync(
+            normalizedQuery, mediaType, year, MaxCandidates, cancellationToken);
+
+        // Collect all unique media IDs
+        var allMediaIds = titleCandidates.Select(t => t.MediaId)
+            .Union(aliasCandidates.Select(a => a.MediaId))
+            .Distinct()
+            .ToList();
+
+        if (allMediaIds.Count == 0)
+            return Array.Empty<MetadataSearchResult>();
+
+        // Batch-load IMDB details for external IDs
+        var imdbDetails = await _imdbDetailsRepo.GetByMediaIdsAsync(allMediaIds, cancellationToken);
+
+        var results = new Dictionary<int, MetadataSearchResult>();
+
+        // Score canonical title matches
+        foreach (var title in titleCandidates)
+        {
+            if (!imdbDetails.TryGetValue(title.MediaId, out var details))
+                continue;
+
+            var similarity = _normalizer.ComputeSimilarity(query, title.CanonicalTitle);
+            var score = ApplyYearBonus(similarity, year, title.Year);
+
+            UpdateBestResult(results, title, details.Tconst, score);
+        }
+
+        // Score alias matches
+        foreach (var alias in aliasCandidates)
+        {
+            if (!imdbDetails.TryGetValue(alias.MediaId, out var details))
+                continue;
+
+            var similarity = _normalizer.ComputeSimilarity(query, alias.AliasTitle);
+            var score = Math.Max(0m, ApplyYearBonus(similarity, year, alias.MediaTitle?.Year) - AliasPenalty);
+
+            // Get the MediaTitle (from canonical results or the alias navigation)
+            var mediaTitle = titleCandidates.FirstOrDefault(t => t.MediaId == alias.MediaId)
+                             ?? alias.MediaTitle;
+            if (mediaTitle is null)
+                continue;
+
+            UpdateBestResult(results, mediaTitle, details.Tconst, score);
+        }
+
+        return results.Values
+            .OrderByDescending(r => r.ConfidenceScore)
+            .ToList();
+    }
+
+    public async Task<MetadataSearchResult?> SearchByExternalIdAsync(
+        string externalId,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(externalId))
+            return null;
+
+        var details = await _imdbDetailsRepo.GetByTconstAsync(externalId, cancellationToken);
+        if (details is null)
+            return null;
+
+        var title = await _titleRepo.GetByIdAsync(details.MediaId, cancellationToken);
+        if (title is null)
+            return null;
+
+        return new MetadataSearchResult
+        {
+            MediaId = title.MediaId,
+            CanonicalTitle = title.CanonicalTitle,
+            Year = title.Year,
+            Type = MediaTypeToString(title.Type),
+            ConfidenceScore = 1.0m,
+            ExternalId = details.Tconst
+        };
+    }
+
+    public async Task<IReadOnlyList<EpisodeInfo>> GetEpisodeListAsync(
+        int titleId,
+        int? season = null,
+        CancellationToken cancellationToken = default)
+    {
+        var episodes = await _episodeRepo.GetByMediaIdAsync(titleId, cancellationToken);
+
+        if (season.HasValue)
+            episodes = episodes.Where(e => e.Season == season.Value).ToList();
+
+        return episodes.Select(e => new EpisodeInfo
+        {
+            Season = e.Season,
+            EpisodeNumber = e.EpisodeNumber,
+            Title = null // IMDB episode titles not stored in MediaEpisode entity
+        }).ToList();
+    }
+
+    public async Task<RatingInfo?> GetRatingsAsync(
+        int titleId,
+        CancellationToken cancellationToken = default)
+    {
+        var rating = await _ratingRepo.GetByMediaIdAndSourceAsync(titleId, ImdbSourceId, cancellationToken);
+        if (rating is null)
+            return null;
+
+        return new RatingInfo
+        {
+            Rating = rating.Rating,
+            VoteCount = rating.VoteCount
+        };
+    }
+
+    private static decimal ApplyYearBonus(decimal similarity, int? queryYear, int? candidateYear)
+    {
+        if (queryYear.HasValue && candidateYear.HasValue && queryYear.Value == candidateYear.Value)
+            return Math.Min(1.0m, similarity + YearBonus);
+
+        return similarity;
+    }
+
+    private static void UpdateBestResult(
+        Dictionary<int, MetadataSearchResult> results,
+        MediaTitle title,
+        string tconst,
+        decimal score)
+    {
+        if (results.TryGetValue(title.MediaId, out var existing) && existing.ConfidenceScore >= score)
+            return;
+
+        results[title.MediaId] = new MetadataSearchResult
+        {
+            MediaId = title.MediaId,
+            CanonicalTitle = title.CanonicalTitle,
+            Year = title.Year,
+            Type = MediaTypeToString(title.Type),
+            ConfidenceScore = score,
+            ExternalId = tconst
+        };
+    }
+
+    public static MediaType? ParseMediaType(string? type)
+    {
+        if (string.IsNullOrEmpty(type))
+            return null;
+
+        return type.ToLowerInvariant() switch
+        {
+            "movie" => MediaType.Movie,
+            "series" => MediaType.Series,
+            "episode" => MediaType.Episode,
+            _ => null
+        };
+    }
+
+    public static string MediaTypeToString(MediaType type)
+    {
+        return type switch
+        {
+            MediaType.Movie => "movie",
+            MediaType.Series => "series",
+            MediaType.Episode => "episode",
+            _ => type.ToString().ToLowerInvariant()
+        };
+    }
+}

--- a/src/SeriesScraper.Web/Program.cs
+++ b/src/SeriesScraper.Web/Program.cs
@@ -3,8 +3,10 @@ using Microsoft.AspNetCore.Components.Web;
 using Serilog;
 using SeriesScraper.Application.Services;
 using SeriesScraper.Domain.Interfaces;
+using SeriesScraper.Infrastructure.Data;
 using SeriesScraper.Infrastructure.Repositories;
 using SeriesScraper.Infrastructure.Services;
+using SeriesScraper.Infrastructure.Services.Imdb;
 using SeriesScraper.Web.BackgroundServices;
 using SeriesScraper.Web.Data;
 using SeriesScraper.Web.Logging;
@@ -39,6 +41,15 @@ try
     // Scoped services
     builder.Services.AddScoped<IScrapeRunService, ScrapeRunService>();
     builder.Services.AddScoped<IScrapeRunRepository, ScrapeRunRepository>();
+
+    // IMDB matching engine
+    builder.Services.AddSingleton<ITitleNormalizer, TitleNormalizer>();
+    builder.Services.AddScoped<IMediaTitleRepository, MediaTitleRepository>();
+    builder.Services.AddScoped<IMediaEpisodeRepository, MediaEpisodeRepository>();
+    builder.Services.AddScoped<IMediaRatingRepository, MediaRatingRepository>();
+    builder.Services.AddScoped<IImdbTitleDetailsRepository, ImdbTitleDetailsRepository>();
+    builder.Services.AddScoped<IMetadataSource, ImdbMetadataSource>();
+    builder.Services.AddScoped<IImdbMatchingService, ImdbMatchingService>();
 
     // Background service
     builder.Services.AddHostedService<ScrapeRunBackgroundService>();

--- a/tests/SeriesScraper.Application.Tests/Services/ImdbMatchingServiceTests.cs
+++ b/tests/SeriesScraper.Application.Tests/Services/ImdbMatchingServiceTests.cs
@@ -1,0 +1,238 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using SeriesScraper.Application.Services;
+using SeriesScraper.Domain.Interfaces;
+using SeriesScraper.Domain.ValueObjects;
+
+namespace SeriesScraper.Application.Tests.Services;
+
+public class ImdbMatchingServiceTests
+{
+    private readonly Mock<IMetadataSource> _metadataSourceMock = new();
+    private readonly Mock<ITitleNormalizer> _normalizerMock = new();
+    private readonly Mock<ILogger<ImdbMatchingService>> _loggerMock = new();
+    private readonly ImdbMatchingService _sut;
+
+    public ImdbMatchingServiceTests()
+    {
+        _sut = new ImdbMatchingService(
+            _metadataSourceMock.Object,
+            _normalizerMock.Object,
+            _loggerMock.Object);
+    }
+
+    // ── Constructor ────────────────────────────────────────────────
+
+    [Fact]
+    public void Constructor_NullMetadataSource_ThrowsArgumentNullException()
+    {
+        var act = () => new ImdbMatchingService(null!, _normalizerMock.Object, _loggerMock.Object);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("metadataSource");
+    }
+
+    [Fact]
+    public void Constructor_NullNormalizer_ThrowsArgumentNullException()
+    {
+        var act = () => new ImdbMatchingService(_metadataSourceMock.Object, null!, _loggerMock.Object);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("normalizer");
+    }
+
+    [Fact]
+    public void Constructor_NullLogger_ThrowsArgumentNullException()
+    {
+        var act = () => new ImdbMatchingService(_metadataSourceMock.Object, _normalizerMock.Object, null!);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("logger");
+    }
+
+    // ── FindMatchesAsync ───────────────────────────────────────────
+
+    [Fact]
+    public async Task FindMatchesAsync_NullTitle_ReturnsEmpty()
+    {
+        var result = await _sut.FindMatchesAsync(null!);
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task FindMatchesAsync_EmptyTitle_ReturnsEmpty()
+    {
+        var result = await _sut.FindMatchesAsync("");
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task FindMatchesAsync_WhitespaceTitle_ReturnsEmpty()
+    {
+        var result = await _sut.FindMatchesAsync("   ");
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task FindMatchesAsync_TitleWithYear_ExtractsYearAndSearches()
+    {
+        _normalizerMock.Setup(n => n.ExtractYear("Breaking Bad (2008)")).Returns(2008);
+        _normalizerMock.Setup(n => n.StripYear("Breaking Bad (2008)")).Returns("Breaking Bad");
+
+        var expected = new List<MetadataSearchResult>
+        {
+            new() { CanonicalTitle = "Breaking Bad", Year = 2008, Type = "series", ConfidenceScore = 0.95m, ExternalId = "tt0903747" }
+        };
+
+        _metadataSourceMock
+            .Setup(m => m.SearchByTitleAsync("Breaking Bad", 2008, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expected);
+
+        var result = await _sut.FindMatchesAsync("Breaking Bad (2008)");
+
+        result.Should().BeEquivalentTo(expected);
+        _metadataSourceMock.Verify(m => m.SearchByTitleAsync("Breaking Bad", 2008, null, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task FindMatchesAsync_TitleWithoutYear_SearchesWithNullYear()
+    {
+        _normalizerMock.Setup(n => n.ExtractYear("Breaking Bad")).Returns((int?)null);
+        _normalizerMock.Setup(n => n.StripYear("Breaking Bad")).Returns("Breaking Bad");
+
+        var expected = new List<MetadataSearchResult>
+        {
+            new() { CanonicalTitle = "Breaking Bad", Year = 2008, Type = "series", ConfidenceScore = 0.9m, ExternalId = "tt0903747" }
+        };
+
+        _metadataSourceMock
+            .Setup(m => m.SearchByTitleAsync("Breaking Bad", null, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expected);
+
+        var result = await _sut.FindMatchesAsync("Breaking Bad");
+
+        result.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task FindMatchesAsync_WithType_PassesTypeToSource()
+    {
+        _normalizerMock.Setup(n => n.ExtractYear("The Matrix")).Returns((int?)null);
+        _normalizerMock.Setup(n => n.StripYear("The Matrix")).Returns("The Matrix");
+        _metadataSourceMock
+            .Setup(m => m.SearchByTitleAsync("The Matrix", null, "movie", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<MetadataSearchResult>());
+
+        await _sut.FindMatchesAsync("The Matrix", "movie");
+
+        _metadataSourceMock.Verify(
+            m => m.SearchByTitleAsync("The Matrix", null, "movie", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task FindMatchesAsync_NoMatchesFound_ReturnsEmpty()
+    {
+        _normalizerMock.Setup(n => n.ExtractYear(It.IsAny<string>())).Returns((int?)null);
+        _normalizerMock.Setup(n => n.StripYear(It.IsAny<string>())).Returns("NonexistentMovie");
+        _metadataSourceMock
+            .Setup(m => m.SearchByTitleAsync(It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<MetadataSearchResult>());
+
+        var result = await _sut.FindMatchesAsync("NonexistentMovie");
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task FindMatchesAsync_StripYearReturnsEmpty_ReturnsEmpty()
+    {
+        _normalizerMock.Setup(n => n.ExtractYear("(2024)")).Returns(2024);
+        _normalizerMock.Setup(n => n.StripYear("(2024)")).Returns("");
+
+        var result = await _sut.FindMatchesAsync("(2024)");
+
+        result.Should().BeEmpty();
+    }
+
+    // ── FindBestMatchAsync ─────────────────────────────────────────
+
+    [Fact]
+    public async Task FindBestMatchAsync_NullTitle_ReturnsNull()
+    {
+        var result = await _sut.FindBestMatchAsync(null!);
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task FindBestMatchAsync_HighConfidenceMatch_ReturnsIt()
+    {
+        _normalizerMock.Setup(n => n.ExtractYear("Breaking Bad")).Returns((int?)null);
+        _normalizerMock.Setup(n => n.StripYear("Breaking Bad")).Returns("Breaking Bad");
+
+        var results = new List<MetadataSearchResult>
+        {
+            new() { CanonicalTitle = "Breaking Bad", Year = 2008, Type = "series", ConfidenceScore = 0.95m, ExternalId = "tt0903747" },
+            new() { CanonicalTitle = "Breaking Badly", Year = 2010, Type = "movie", ConfidenceScore = 0.6m, ExternalId = "tt9999999" }
+        };
+
+        _metadataSourceMock
+            .Setup(m => m.SearchByTitleAsync(It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(results);
+
+        var result = await _sut.FindBestMatchAsync("Breaking Bad");
+
+        result.Should().NotBeNull();
+        result!.ExternalId.Should().Be("tt0903747");
+        result.ConfidenceScore.Should().Be(0.95m);
+    }
+
+    [Fact]
+    public async Task FindBestMatchAsync_BelowThreshold_ReturnsNull()
+    {
+        _normalizerMock.Setup(n => n.ExtractYear("Some Movie")).Returns((int?)null);
+        _normalizerMock.Setup(n => n.StripYear("Some Movie")).Returns("Some Movie");
+
+        var results = new List<MetadataSearchResult>
+        {
+            new() { CanonicalTitle = "Different Movie", Year = 2020, Type = "movie", ConfidenceScore = 0.3m, ExternalId = "tt1111111" }
+        };
+
+        _metadataSourceMock
+            .Setup(m => m.SearchByTitleAsync(It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(results);
+
+        var result = await _sut.FindBestMatchAsync("Some Movie");
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task FindBestMatchAsync_ExactThreshold_ReturnsMatch()
+    {
+        _normalizerMock.Setup(n => n.ExtractYear("Movie")).Returns((int?)null);
+        _normalizerMock.Setup(n => n.StripYear("Movie")).Returns("Movie");
+
+        var results = new List<MetadataSearchResult>
+        {
+            new() { CanonicalTitle = "Movie", Year = 2020, Type = "movie", ConfidenceScore = 0.5m, ExternalId = "tt1234567" }
+        };
+
+        _metadataSourceMock
+            .Setup(m => m.SearchByTitleAsync(It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(results);
+
+        var result = await _sut.FindBestMatchAsync("Movie");
+
+        result.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task FindBestMatchAsync_EmptyResults_ReturnsNull()
+    {
+        _normalizerMock.Setup(n => n.ExtractYear("Unknown")).Returns((int?)null);
+        _normalizerMock.Setup(n => n.StripYear("Unknown")).Returns("Unknown");
+        _metadataSourceMock
+            .Setup(m => m.SearchByTitleAsync(It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<MetadataSearchResult>());
+
+        var result = await _sut.FindBestMatchAsync("Unknown");
+
+        result.Should().BeNull();
+    }
+}

--- a/tests/SeriesScraper.Application.Tests/Services/TitleNormalizerTests.cs
+++ b/tests/SeriesScraper.Application.Tests/Services/TitleNormalizerTests.cs
@@ -1,0 +1,294 @@
+using FluentAssertions;
+using SeriesScraper.Application.Services;
+
+namespace SeriesScraper.Application.Tests.Services;
+
+public class TitleNormalizerTests
+{
+    private readonly TitleNormalizer _sut = new();
+
+    // ── Normalize ──────────────────────────────────────────────────
+
+    [Fact]
+    public void Normalize_NullInput_ReturnsEmpty()
+    {
+        _sut.Normalize(null!).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Normalize_EmptyInput_ReturnsEmpty()
+    {
+        _sut.Normalize("").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Normalize_WhitespaceInput_ReturnsEmpty()
+    {
+        _sut.Normalize("   ").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Normalize_SimpleTitle_Lowercases()
+    {
+        _sut.Normalize("Breaking Bad").Should().Be("breaking bad");
+    }
+
+    [Fact]
+    public void Normalize_TitleWithPunctuation_RemovesPunctuation()
+    {
+        _sut.Normalize("Spider-Man: No Way Home").Should().Be("spiderman no way home");
+    }
+
+    [Fact]
+    public void Normalize_TitleWithDiacritics_StripsDiacritics()
+    {
+        _sut.Normalize("Amélie").Should().Be("amelie");
+    }
+
+    [Fact]
+    public void Normalize_CzechDiacritics_StripsDiacritics()
+    {
+        _sut.Normalize("Příběhy ze šťastného kraje").Should().Be("pribehy ze stastneho kraje");
+    }
+
+    [Fact]
+    public void Normalize_TitleWithYear_StripsYear()
+    {
+        _sut.Normalize("The Matrix (1999)").Should().Be("the matrix");
+    }
+
+    [Fact]
+    public void Normalize_TitleWithExtraWhitespace_CollapsesWhitespace()
+    {
+        _sut.Normalize("  The   Matrix   ").Should().Be("the matrix");
+    }
+
+    [Fact]
+    public void Normalize_TitleWithNumbers_PreservesNumbers()
+    {
+        _sut.Normalize("2001 A Space Odyssey").Should().Be("2001 a space odyssey");
+    }
+
+    [Fact]
+    public void Normalize_MixedCase_NormalizesConsistently()
+    {
+        _sut.Normalize("ThE dArK kNiGhT").Should().Be("the dark knight");
+    }
+
+    [Fact]
+    public void Normalize_TitleWithApostrophe_RemovesApostrophe()
+    {
+        _sut.Normalize("Schindler's List").Should().Be("schindlers list");
+    }
+
+    // ── ExtractYear ────────────────────────────────────────────────
+
+    [Fact]
+    public void ExtractYear_NullInput_ReturnsNull()
+    {
+        _sut.ExtractYear(null!).Should().BeNull();
+    }
+
+    [Fact]
+    public void ExtractYear_EmptyInput_ReturnsNull()
+    {
+        _sut.ExtractYear("").Should().BeNull();
+    }
+
+    [Fact]
+    public void ExtractYear_NoYear_ReturnsNull()
+    {
+        _sut.ExtractYear("Breaking Bad").Should().BeNull();
+    }
+
+    [Fact]
+    public void ExtractYear_YearInParentheses_ExtractsYear()
+    {
+        _sut.ExtractYear("The Matrix (1999)").Should().Be(1999);
+    }
+
+    [Fact]
+    public void ExtractYear_YearNotInParentheses_ReturnsNull()
+    {
+        _sut.ExtractYear("2001 A Space Odyssey").Should().BeNull();
+    }
+
+    [Fact]
+    public void ExtractYear_MultipleYears_ExtractsFirst()
+    {
+        _sut.ExtractYear("Movie (2020) (2021)").Should().Be(2020);
+    }
+
+    [Fact]
+    public void ExtractYear_RecentYear_Extracts()
+    {
+        _sut.ExtractYear("New Movie (2025)").Should().Be(2025);
+    }
+
+    // ── StripYear ──────────────────────────────────────────────────
+
+    [Fact]
+    public void StripYear_NullInput_ReturnsEmpty()
+    {
+        _sut.StripYear(null!).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void StripYear_EmptyInput_ReturnsEmpty()
+    {
+        _sut.StripYear("").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void StripYear_NoYear_ReturnsSameTrimmed()
+    {
+        _sut.StripYear("Breaking Bad").Should().Be("Breaking Bad");
+    }
+
+    [Fact]
+    public void StripYear_YearSuffix_RemovesYear()
+    {
+        _sut.StripYear("The Matrix (1999)").Should().Be("The Matrix");
+    }
+
+    [Fact]
+    public void StripYear_YearMidString_RemovesYear()
+    {
+        _sut.StripYear("Movie (2020) Extended").Should().Be("Movie Extended");
+    }
+
+    // ── ComputeSimilarity ──────────────────────────────────────────
+
+    [Fact]
+    public void ComputeSimilarity_BothEmpty_Returns1()
+    {
+        _sut.ComputeSimilarity("", "").Should().Be(1.0m);
+    }
+
+    [Fact]
+    public void ComputeSimilarity_OneEmpty_Returns0()
+    {
+        _sut.ComputeSimilarity("test", "").Should().Be(0.0m);
+    }
+
+    [Fact]
+    public void ComputeSimilarity_OtherEmpty_Returns0()
+    {
+        _sut.ComputeSimilarity("", "test").Should().Be(0.0m);
+    }
+
+    [Fact]
+    public void ComputeSimilarity_BothNull_Returns1()
+    {
+        _sut.ComputeSimilarity(null!, null!).Should().Be(1.0m);
+    }
+
+    [Fact]
+    public void ComputeSimilarity_OneNull_Returns0()
+    {
+        _sut.ComputeSimilarity("test", null!).Should().Be(0.0m);
+    }
+
+    [Fact]
+    public void ComputeSimilarity_IdenticalStrings_Returns1()
+    {
+        _sut.ComputeSimilarity("Breaking Bad", "Breaking Bad").Should().Be(1.0m);
+    }
+
+    [Fact]
+    public void ComputeSimilarity_CaseInsensitive_Returns1()
+    {
+        _sut.ComputeSimilarity("breaking bad", "BREAKING BAD").Should().Be(1.0m);
+    }
+
+    [Fact]
+    public void ComputeSimilarity_DiacriticsEquivalent_Returns1()
+    {
+        _sut.ComputeSimilarity("Amélie", "Amelie").Should().Be(1.0m);
+    }
+
+    [Fact]
+    public void ComputeSimilarity_SimilarStrings_ReturnsHighScore()
+    {
+        var score = _sut.ComputeSimilarity("Breaking Bad", "Breaking Bed");
+        score.Should().BeGreaterThan(0.8m).And.BeLessThan(1.0m);
+    }
+
+    [Fact]
+    public void ComputeSimilarity_DifferentStrings_ReturnsLowScore()
+    {
+        var score = _sut.ComputeSimilarity("Breaking Bad", "Game of Thrones");
+        score.Should().BeLessThan(0.5m);
+    }
+
+    [Fact]
+    public void ComputeSimilarity_WithYearsInBoth_NormalizesOut()
+    {
+        var score = _sut.ComputeSimilarity("The Matrix (1999)", "The Matrix (2003)");
+        score.Should().Be(1.0m);
+    }
+
+    // ── Internal: RemoveDiacritics ─────────────────────────────────
+
+    [Fact]
+    public void RemoveDiacritics_PlainAscii_Unchanged()
+    {
+        TitleNormalizer.RemoveDiacritics("Hello World").Should().Be("Hello World");
+    }
+
+    [Fact]
+    public void RemoveDiacritics_AccentedCharacters_Stripped()
+    {
+        TitleNormalizer.RemoveDiacritics("é à ü ö ñ").Should().Be("e a u o n");
+    }
+
+    [Fact]
+    public void RemoveDiacritics_CzechCharacters_Stripped()
+    {
+        TitleNormalizer.RemoveDiacritics("čřžšďťňěů").Should().Be("crzsdtneu");
+    }
+
+    // ── Internal: LevenshteinDistance ───────────────────────────────
+
+    [Fact]
+    public void LevenshteinDistance_IdenticalStrings_ReturnsZero()
+    {
+        TitleNormalizer.LevenshteinDistance("abc", "abc").Should().Be(0);
+    }
+
+    [Fact]
+    public void LevenshteinDistance_OneEmpty_ReturnsOtherLength()
+    {
+        TitleNormalizer.LevenshteinDistance("", "abc").Should().Be(3);
+    }
+
+    [Fact]
+    public void LevenshteinDistance_OtherEmpty_ReturnsFirstLength()
+    {
+        TitleNormalizer.LevenshteinDistance("abc", "").Should().Be(3);
+    }
+
+    [Fact]
+    public void LevenshteinDistance_OneCharDifference_ReturnsOne()
+    {
+        TitleNormalizer.LevenshteinDistance("abc", "adc").Should().Be(1);
+    }
+
+    [Fact]
+    public void LevenshteinDistance_Insertion_ReturnsOne()
+    {
+        TitleNormalizer.LevenshteinDistance("abc", "abcd").Should().Be(1);
+    }
+
+    [Fact]
+    public void LevenshteinDistance_Deletion_ReturnsOne()
+    {
+        TitleNormalizer.LevenshteinDistance("abcd", "abc").Should().Be(1);
+    }
+
+    [Fact]
+    public void LevenshteinDistance_CompletelyDifferent_ReturnsMaxLength()
+    {
+        TitleNormalizer.LevenshteinDistance("abc", "xyz").Should().Be(3);
+    }
+}

--- a/tests/SeriesScraper.Infrastructure.Tests/Data/ImdbTitleDetailsRepositoryTests.cs
+++ b/tests/SeriesScraper.Infrastructure.Tests/Data/ImdbTitleDetailsRepositoryTests.cs
@@ -1,0 +1,154 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using SeriesScraper.Domain.Entities;
+using SeriesScraper.Domain.Enums;
+using SeriesScraper.Infrastructure.Data;
+
+namespace SeriesScraper.Infrastructure.Tests.Data;
+
+public class ImdbTitleDetailsRepositoryTests : IDisposable
+{
+    private readonly AppDbContext _context;
+    private readonly ImdbTitleDetailsRepository _sut;
+
+    public ImdbTitleDetailsRepositoryTests()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        _context = new AppDbContext(options);
+
+        _context.DataSources.Add(new DataSource { SourceId = 1, Name = "IMDB" });
+        _context.SaveChanges();
+
+        _sut = new ImdbTitleDetailsRepository(_context);
+    }
+
+    // ── GetByTconstAsync ───────────────────────────────────────────
+
+    [Fact]
+    public async Task GetByTconstAsync_NullTconst_ReturnsNull()
+    {
+        var result = await _sut.GetByTconstAsync(null!);
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetByTconstAsync_EmptyTconst_ReturnsNull()
+    {
+        var result = await _sut.GetByTconstAsync("");
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetByTconstAsync_Exists_ReturnsDetails()
+    {
+        SeedTitleWithDetails(1, "The Matrix", "tt0133093", "Action,Sci-Fi");
+
+        var result = await _sut.GetByTconstAsync("tt0133093");
+
+        result.Should().NotBeNull();
+        result!.Tconst.Should().Be("tt0133093");
+        result.MediaId.Should().Be(1);
+        result.GenreString.Should().Be("Action,Sci-Fi");
+    }
+
+    [Fact]
+    public async Task GetByTconstAsync_NotExists_ReturnsNull()
+    {
+        var result = await _sut.GetByTconstAsync("tt0000000");
+        result.Should().BeNull();
+    }
+
+    // ── GetByMediaIdAsync ──────────────────────────────────────────
+
+    [Fact]
+    public async Task GetByMediaIdAsync_Exists_ReturnsDetails()
+    {
+        SeedTitleWithDetails(1, "The Matrix", "tt0133093");
+
+        var result = await _sut.GetByMediaIdAsync(1);
+
+        result.Should().NotBeNull();
+        result!.Tconst.Should().Be("tt0133093");
+    }
+
+    [Fact]
+    public async Task GetByMediaIdAsync_NotExists_ReturnsNull()
+    {
+        var result = await _sut.GetByMediaIdAsync(999);
+        result.Should().BeNull();
+    }
+
+    // ── GetByMediaIdsAsync ─────────────────────────────────────────
+
+    [Fact]
+    public async Task GetByMediaIdsAsync_EmptyList_ReturnsEmptyDictionary()
+    {
+        var result = await _sut.GetByMediaIdsAsync(Array.Empty<int>());
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetByMediaIdsAsync_AllExist_ReturnsDictionary()
+    {
+        SeedTitleWithDetails(1, "The Matrix", "tt0133093");
+        SeedTitleWithDetails(2, "Inception", "tt1375666");
+
+        var result = await _sut.GetByMediaIdsAsync(new[] { 1, 2 });
+
+        result.Should().HaveCount(2);
+        result[1].Tconst.Should().Be("tt0133093");
+        result[2].Tconst.Should().Be("tt1375666");
+    }
+
+    [Fact]
+    public async Task GetByMediaIdsAsync_SomeExist_ReturnsOnlyExisting()
+    {
+        SeedTitleWithDetails(1, "The Matrix", "tt0133093");
+
+        var result = await _sut.GetByMediaIdsAsync(new[] { 1, 999 });
+
+        result.Should().HaveCount(1);
+        result.Should().ContainKey(1);
+        result.Should().NotContainKey(999);
+    }
+
+    [Fact]
+    public async Task GetByMediaIdsAsync_NoneExist_ReturnsEmptyDictionary()
+    {
+        var result = await _sut.GetByMediaIdsAsync(new[] { 998, 999 });
+        result.Should().BeEmpty();
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────
+
+    private void SeedTitleWithDetails(int mediaId, string title, string tconst, string? genres = null)
+    {
+        _context.MediaTitles.Add(new MediaTitle
+        {
+            MediaId = mediaId,
+            CanonicalTitle = title,
+            Year = 1999,
+            Type = MediaType.Movie,
+            SourceId = 1,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        _context.SaveChanges();
+
+        _context.ImdbTitleDetails.Add(new ImdbTitleDetails
+        {
+            MediaId = mediaId,
+            Tconst = tconst,
+            GenreString = genres
+        });
+        _context.SaveChanges();
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+    }
+}

--- a/tests/SeriesScraper.Infrastructure.Tests/Data/MediaRatingRepositoryTests.cs
+++ b/tests/SeriesScraper.Infrastructure.Tests/Data/MediaRatingRepositoryTests.cs
@@ -1,0 +1,114 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using SeriesScraper.Domain.Entities;
+using SeriesScraper.Infrastructure.Data;
+
+namespace SeriesScraper.Infrastructure.Tests.Data;
+
+public class MediaRatingRepositoryTests : IDisposable
+{
+    private readonly AppDbContext _context;
+    private readonly MediaRatingRepository _sut;
+
+    public MediaRatingRepositoryTests()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        _context = new AppDbContext(options);
+
+        _context.DataSources.Add(new DataSource { SourceId = 1, Name = "IMDB" });
+        _context.DataSources.Add(new DataSource { SourceId = 2, Name = "CSFD" });
+        _context.SaveChanges();
+
+        _sut = new MediaRatingRepository(_context);
+    }
+
+    [Fact]
+    public async Task GetByMediaIdAndSourceAsync_Exists_ReturnsRating()
+    {
+        SeedRating(1, 1, 8.7m, 2000000);
+
+        var result = await _sut.GetByMediaIdAndSourceAsync(1, 1);
+
+        result.Should().NotBeNull();
+        result!.Rating.Should().Be(8.7m);
+        result.VoteCount.Should().Be(2000000);
+    }
+
+    [Fact]
+    public async Task GetByMediaIdAndSourceAsync_WrongSource_ReturnsNull()
+    {
+        SeedRating(1, 1, 8.7m, 2000000);
+
+        var result = await _sut.GetByMediaIdAndSourceAsync(1, 2);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetByMediaIdAndSourceAsync_WrongMediaId_ReturnsNull()
+    {
+        SeedRating(1, 1, 8.7m, 2000000);
+
+        var result = await _sut.GetByMediaIdAndSourceAsync(999, 1);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetByMediaIdAndSourceAsync_MultipleRatings_ReturnsCorrectOne()
+    {
+        SeedRating(1, 1, 8.7m, 2000000);
+        SeedRating(1, 2, 85.0m, 50000);
+
+        var imdbRating = await _sut.GetByMediaIdAndSourceAsync(1, 1);
+        var csfdRating = await _sut.GetByMediaIdAndSourceAsync(1, 2);
+
+        imdbRating!.Rating.Should().Be(8.7m);
+        csfdRating!.Rating.Should().Be(85.0m);
+    }
+
+    [Fact]
+    public async Task GetByMediaIdAndSourceAsync_NoRatings_ReturnsNull()
+    {
+        var result = await _sut.GetByMediaIdAndSourceAsync(1, 1);
+        result.Should().BeNull();
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────
+
+    private void SeedRating(int mediaId, int sourceId, decimal rating, int voteCount)
+    {
+        // Ensure media title exists
+        if (!_context.MediaTitles.Any(t => t.MediaId == mediaId))
+        {
+            _context.MediaTitles.Add(new MediaTitle
+            {
+                MediaId = mediaId,
+                CanonicalTitle = $"Title {mediaId}",
+                Year = 2020,
+                Type = Domain.Enums.MediaType.Movie,
+                SourceId = 1,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            });
+            _context.SaveChanges();
+        }
+
+        _context.MediaRatings.Add(new MediaRating
+        {
+            MediaId = mediaId,
+            SourceId = sourceId,
+            Rating = rating,
+            VoteCount = voteCount
+        });
+        _context.SaveChanges();
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+    }
+}

--- a/tests/SeriesScraper.Infrastructure.Tests/Data/MediaTitleRepositoryTests.cs
+++ b/tests/SeriesScraper.Infrastructure.Tests/Data/MediaTitleRepositoryTests.cs
@@ -1,0 +1,270 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using SeriesScraper.Domain.Entities;
+using SeriesScraper.Domain.Enums;
+using SeriesScraper.Infrastructure.Data;
+
+namespace SeriesScraper.Infrastructure.Tests.Data;
+
+public class MediaTitleRepositoryTests : IDisposable
+{
+    private readonly AppDbContext _context;
+    private readonly MediaTitleRepository _sut;
+
+    public MediaTitleRepositoryTests()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        _context = new AppDbContext(options);
+
+        _context.DataSources.Add(new DataSource { SourceId = 1, Name = "IMDB" });
+        _context.SaveChanges();
+
+        _sut = new MediaTitleRepository(_context);
+    }
+
+    // ── SearchByTitleAsync ─────────────────────────────────────────
+
+    [Fact]
+    public async Task SearchByTitleAsync_EmptyTerm_ReturnsEmpty()
+    {
+        var result = await _sut.SearchByTitleAsync("");
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task SearchByTitleAsync_NullTerm_ReturnsEmpty()
+    {
+        var result = await _sut.SearchByTitleAsync(null!);
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task SearchByTitleAsync_ExactMatch_ReturnsTitle()
+    {
+        SeedTitle(1, "The Matrix", 1999, MediaType.Movie);
+
+        var result = await _sut.SearchByTitleAsync("the matrix");
+
+        result.Should().HaveCount(1);
+        result[0].CanonicalTitle.Should().Be("The Matrix");
+    }
+
+    [Fact]
+    public async Task SearchByTitleAsync_PartialMatch_ReturnsTitle()
+    {
+        SeedTitle(1, "The Matrix", 1999, MediaType.Movie);
+
+        var result = await _sut.SearchByTitleAsync("matrix");
+
+        result.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task SearchByTitleAsync_CaseInsensitive_ReturnsTitle()
+    {
+        SeedTitle(1, "Breaking Bad", 2008, MediaType.Series);
+
+        var result = await _sut.SearchByTitleAsync("breaking bad");
+
+        result.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task SearchByTitleAsync_NoMatch_ReturnsEmpty()
+    {
+        SeedTitle(1, "The Matrix", 1999, MediaType.Movie);
+
+        var result = await _sut.SearchByTitleAsync("inception");
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task SearchByTitleAsync_TypeFilter_FiltersCorrectly()
+    {
+        SeedTitle(1, "Breaking Bad", 2008, MediaType.Series);
+        SeedTitle(2, "Breaking Bad Movie", 2020, MediaType.Movie);
+
+        var result = await _sut.SearchByTitleAsync("breaking bad", MediaType.Series);
+
+        result.Should().HaveCount(1);
+        result[0].Type.Should().Be(MediaType.Series);
+    }
+
+    [Fact]
+    public async Task SearchByTitleAsync_YearFilter_FiltersCorrectly()
+    {
+        SeedTitle(1, "The Matrix", 1999, MediaType.Movie);
+        SeedTitle(2, "The Matrix Resurrections", 2021, MediaType.Movie);
+
+        var result = await _sut.SearchByTitleAsync("the matrix", year: 1999);
+
+        result.Should().HaveCount(1);
+        result[0].Year.Should().Be(1999);
+    }
+
+    [Fact]
+    public async Task SearchByTitleAsync_MaxResults_LimitsResults()
+    {
+        for (int i = 1; i <= 5; i++)
+            SeedTitle(i, $"Test Movie {i}", 2020, MediaType.Movie);
+
+        var result = await _sut.SearchByTitleAsync("test movie", maxResults: 3);
+
+        result.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public async Task SearchByTitleAsync_MultipleMatches_OrderedByTitle()
+    {
+        SeedTitle(1, "Breaking Bad", 2008, MediaType.Series);
+        SeedTitle(2, "Better Call Saul: Breaking Bad Crossover", 2022, MediaType.Movie);
+
+        var result = await _sut.SearchByTitleAsync("breaking bad");
+
+        result.Should().HaveCount(2);
+        string.Compare(result[0].CanonicalTitle, result[1].CanonicalTitle, StringComparison.Ordinal)
+            .Should().BeLessThan(0);
+    }
+
+    // ── SearchByAliasAsync ─────────────────────────────────────────
+
+    [Fact]
+    public async Task SearchByAliasAsync_EmptyTerm_ReturnsEmpty()
+    {
+        var result = await _sut.SearchByAliasAsync("");
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task SearchByAliasAsync_MatchesAlias_ReturnsAliasWithTitle()
+    {
+        SeedTitle(1, "The Matrix", 1999, MediaType.Movie);
+        SeedAlias(1, 1, "Matrix");
+
+        var result = await _sut.SearchByAliasAsync("matrix");
+
+        result.Should().HaveCount(1);
+        result[0].AliasTitle.Should().Be("Matrix");
+        result[0].MediaTitle.Should().NotBeNull();
+        result[0].MediaTitle.CanonicalTitle.Should().Be("The Matrix");
+    }
+
+    [Fact]
+    public async Task SearchByAliasAsync_CaseInsensitive_MatchesAlias()
+    {
+        SeedTitle(1, "Amélie", 2001, MediaType.Movie);
+        SeedAlias(1, 1, "Amelie");
+
+        var result = await _sut.SearchByAliasAsync("amelie");
+
+        result.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task SearchByAliasAsync_TypeFilter_FiltersViaTitleType()
+    {
+        SeedTitle(1, "Breaking Bad", 2008, MediaType.Series);
+        SeedTitle(2, "Breaking", 2020, MediaType.Movie);
+        SeedAlias(1, 1, "BB");
+        SeedAlias(2, 2, "BR");
+
+        var result = await _sut.SearchByAliasAsync("b", MediaType.Series);
+
+        result.Should().HaveCount(1);
+        result[0].MediaTitle.Type.Should().Be(MediaType.Series);
+    }
+
+    [Fact]
+    public async Task SearchByAliasAsync_YearFilter_FiltersViaTitleYear()
+    {
+        SeedTitle(1, "Movie A", 2010, MediaType.Movie);
+        SeedTitle(2, "Movie B", 2020, MediaType.Movie);
+        SeedAlias(1, 1, "Film A");
+        SeedAlias(2, 2, "Film B");
+
+        var result = await _sut.SearchByAliasAsync("film", year: 2020);
+
+        result.Should().HaveCount(1);
+        result[0].AliasTitle.Should().Be("Film B");
+    }
+
+    [Fact]
+    public async Task SearchByAliasAsync_NoMatch_ReturnsEmpty()
+    {
+        SeedTitle(1, "The Matrix", 1999, MediaType.Movie);
+        SeedAlias(1, 1, "Matrix");
+
+        var result = await _sut.SearchByAliasAsync("inception");
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task SearchByAliasAsync_MaxResults_LimitsResults()
+    {
+        SeedTitle(1, "Movie", 2020, MediaType.Movie);
+        for (int i = 1; i <= 5; i++)
+            SeedAlias(i, 1, $"Alias {i}");
+
+        var result = await _sut.SearchByAliasAsync("alias", maxResults: 3);
+
+        result.Should().HaveCount(3);
+    }
+
+    // ── GetByIdAsync ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetByIdAsync_Exists_ReturnsTitle()
+    {
+        SeedTitle(1, "The Matrix", 1999, MediaType.Movie);
+
+        var result = await _sut.GetByIdAsync(1);
+
+        result.Should().NotBeNull();
+        result!.CanonicalTitle.Should().Be("The Matrix");
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_NotExists_ReturnsNull()
+    {
+        var result = await _sut.GetByIdAsync(999);
+        result.Should().BeNull();
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────
+
+    private void SeedTitle(int id, string title, int? year, MediaType type)
+    {
+        _context.MediaTitles.Add(new MediaTitle
+        {
+            MediaId = id,
+            CanonicalTitle = title,
+            Year = year,
+            Type = type,
+            SourceId = 1,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        _context.SaveChanges();
+    }
+
+    private void SeedAlias(int aliasId, int mediaId, string aliasTitle)
+    {
+        _context.MediaTitleAliases.Add(new MediaTitleAlias
+        {
+            AliasId = aliasId,
+            MediaId = mediaId,
+            AliasTitle = aliasTitle
+        });
+        _context.SaveChanges();
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+    }
+}

--- a/tests/SeriesScraper.Infrastructure.Tests/Services/Imdb/ImdbMetadataSourceTests.cs
+++ b/tests/SeriesScraper.Infrastructure.Tests/Services/Imdb/ImdbMetadataSourceTests.cs
@@ -1,0 +1,505 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using NSubstitute.ReturnsExtensions;
+using SeriesScraper.Domain.Entities;
+using SeriesScraper.Domain.Enums;
+using SeriesScraper.Domain.Interfaces;
+using SeriesScraper.Domain.ValueObjects;
+using SeriesScraper.Infrastructure.Services.Imdb;
+
+namespace SeriesScraper.Infrastructure.Tests.Services.Imdb;
+
+public class ImdbMetadataSourceTests
+{
+    private readonly IMediaTitleRepository _titleRepo = Substitute.For<IMediaTitleRepository>();
+    private readonly IMediaEpisodeRepository _episodeRepo = Substitute.For<IMediaEpisodeRepository>();
+    private readonly IMediaRatingRepository _ratingRepo = Substitute.For<IMediaRatingRepository>();
+    private readonly IImdbTitleDetailsRepository _detailsRepo = Substitute.For<IImdbTitleDetailsRepository>();
+    private readonly ITitleNormalizer _normalizer = Substitute.For<ITitleNormalizer>();
+    private readonly ILogger<ImdbMetadataSource> _logger = Substitute.For<ILogger<ImdbMetadataSource>>();
+    private readonly ImdbMetadataSource _sut;
+
+    public ImdbMetadataSourceTests()
+    {
+        _sut = new ImdbMetadataSource(
+            _titleRepo, _episodeRepo, _ratingRepo,
+            _detailsRepo, _normalizer, _logger);
+    }
+
+    // ── Constructor ────────────────────────────────────────────────
+
+    [Fact]
+    public void Constructor_NullTitleRepo_Throws()
+    {
+        var act = () => new ImdbMetadataSource(
+            null!, _episodeRepo, _ratingRepo,
+            _detailsRepo, _normalizer, _logger);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("titleRepo");
+    }
+
+    [Fact]
+    public void Constructor_NullEpisodeRepo_Throws()
+    {
+        var act = () => new ImdbMetadataSource(
+            _titleRepo, null!, _ratingRepo,
+            _detailsRepo, _normalizer, _logger);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("episodeRepo");
+    }
+
+    [Fact]
+    public void Constructor_NullRatingRepo_Throws()
+    {
+        var act = () => new ImdbMetadataSource(
+            _titleRepo, _episodeRepo, null!,
+            _detailsRepo, _normalizer, _logger);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("ratingRepo");
+    }
+
+    [Fact]
+    public void Constructor_NullDetailsRepo_Throws()
+    {
+        var act = () => new ImdbMetadataSource(
+            _titleRepo, _episodeRepo, _ratingRepo,
+            null!, _normalizer, _logger);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("imdbDetailsRepo");
+    }
+
+    [Fact]
+    public void Constructor_NullNormalizer_Throws()
+    {
+        var act = () => new ImdbMetadataSource(
+            _titleRepo, _episodeRepo, _ratingRepo,
+            _detailsRepo, null!, _logger);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("normalizer");
+    }
+
+    [Fact]
+    public void Constructor_NullLogger_Throws()
+    {
+        var act = () => new ImdbMetadataSource(
+            _titleRepo, _episodeRepo, _ratingRepo,
+            _detailsRepo, _normalizer, null!);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("logger");
+    }
+
+    // ── SourceIdentifier ───────────────────────────────────────────
+
+    [Fact]
+    public void SourceIdentifier_ReturnsImdb()
+    {
+        _sut.SourceIdentifier.Should().Be("imdb");
+    }
+
+    // ── SearchByTitleAsync ─────────────────────────────────────────
+
+    [Fact]
+    public async Task SearchByTitleAsync_NullQuery_ReturnsEmpty()
+    {
+        var result = await _sut.SearchByTitleAsync(null!);
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task SearchByTitleAsync_EmptyQuery_ReturnsEmpty()
+    {
+        var result = await _sut.SearchByTitleAsync("");
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task SearchByTitleAsync_NormalizesToEmpty_ReturnsEmpty()
+    {
+        _normalizer.Normalize("!!!").Returns("");
+
+        var result = await _sut.SearchByTitleAsync("!!!");
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task SearchByTitleAsync_ExactCanonicalMatch_ReturnsHighConfidence()
+    {
+        SetupNormalizer();
+
+        var title = CreateMediaTitle(1, "The Matrix", 1999, MediaType.Movie);
+        _titleRepo.SearchByTitleAsync("the matrix", null, null, ImdbMetadataSource.MaxCandidates, Arg.Any<CancellationToken>())
+            .Returns(new[] { title });
+        _titleRepo.SearchByAliasAsync("the matrix", null, null, ImdbMetadataSource.MaxCandidates, Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<MediaTitleAlias>());
+        _detailsRepo.GetByMediaIdsAsync(Arg.Any<IReadOnlyList<int>>(), Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<int, ImdbTitleDetails>
+            {
+                [1] = new() { MediaId = 1, Tconst = "tt0133093" }
+            });
+
+        _normalizer.ComputeSimilarity("The Matrix", "The Matrix").Returns(1.0m);
+
+        var result = await _sut.SearchByTitleAsync("The Matrix");
+
+        result.Should().HaveCount(1);
+        result[0].CanonicalTitle.Should().Be("The Matrix");
+        result[0].ConfidenceScore.Should().Be(1.0m);
+        result[0].ExternalId.Should().Be("tt0133093");
+        result[0].MediaId.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task SearchByTitleAsync_AliasMatch_ReturnsWithPenalty()
+    {
+        SetupNormalizer();
+
+        var title = CreateMediaTitle(1, "The Matrix", 1999, MediaType.Movie);
+        var alias = new MediaTitleAlias { AliasId = 1, MediaId = 1, AliasTitle = "Matrix", MediaTitle = title };
+
+        _titleRepo.SearchByTitleAsync(Arg.Any<string>(), Arg.Any<MediaType?>(), Arg.Any<int?>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<MediaTitle>());
+        _titleRepo.SearchByAliasAsync(Arg.Any<string>(), Arg.Any<MediaType?>(), Arg.Any<int?>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new[] { alias });
+        _detailsRepo.GetByMediaIdsAsync(Arg.Any<IReadOnlyList<int>>(), Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<int, ImdbTitleDetails>
+            {
+                [1] = new() { MediaId = 1, Tconst = "tt0133093" }
+            });
+
+        _normalizer.ComputeSimilarity("Matrix", "Matrix").Returns(1.0m);
+
+        var result = await _sut.SearchByTitleAsync("Matrix");
+
+        result.Should().HaveCount(1);
+        result[0].ConfidenceScore.Should().Be(1.0m - ImdbMetadataSource.AliasPenalty);
+    }
+
+    [Fact]
+    public async Task SearchByTitleAsync_WithYearFilter_AppliesYearBonus()
+    {
+        SetupNormalizer();
+
+        var title = CreateMediaTitle(1, "The Matrix", 1999, MediaType.Movie);
+        _titleRepo.SearchByTitleAsync("the matrix", null, 1999, ImdbMetadataSource.MaxCandidates, Arg.Any<CancellationToken>())
+            .Returns(new[] { title });
+        _titleRepo.SearchByAliasAsync("the matrix", null, 1999, ImdbMetadataSource.MaxCandidates, Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<MediaTitleAlias>());
+        _detailsRepo.GetByMediaIdsAsync(Arg.Any<IReadOnlyList<int>>(), Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<int, ImdbTitleDetails>
+            {
+                [1] = new() { MediaId = 1, Tconst = "tt0133093" }
+            });
+
+        _normalizer.ComputeSimilarity("The Matrix", "The Matrix").Returns(0.9m);
+
+        var result = await _sut.SearchByTitleAsync("The Matrix", year: 1999);
+
+        result.Should().HaveCount(1);
+        result[0].ConfidenceScore.Should().Be(0.9m + ImdbMetadataSource.YearBonus);
+    }
+
+    [Fact]
+    public async Task SearchByTitleAsync_WithTypeFilter_PassesToRepository()
+    {
+        SetupNormalizer();
+
+        _titleRepo.SearchByTitleAsync("the matrix", MediaType.Movie, null, ImdbMetadataSource.MaxCandidates, Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<MediaTitle>());
+        _titleRepo.SearchByAliasAsync("the matrix", MediaType.Movie, null, ImdbMetadataSource.MaxCandidates, Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<MediaTitleAlias>());
+
+        await _sut.SearchByTitleAsync("The Matrix", type: "movie");
+
+        await _titleRepo.Received(1).SearchByTitleAsync("the matrix", MediaType.Movie, null, ImdbMetadataSource.MaxCandidates, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SearchByTitleAsync_MultipleMatches_RankedByConfidence()
+    {
+        SetupNormalizer();
+
+        var title1 = CreateMediaTitle(1, "Breaking Bad", 2008, MediaType.Series);
+        var title2 = CreateMediaTitle(2, "Breaking Badly", 2010, MediaType.Movie);
+
+        _titleRepo.SearchByTitleAsync(Arg.Any<string>(), Arg.Any<MediaType?>(), Arg.Any<int?>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new[] { title1, title2 });
+        _titleRepo.SearchByAliasAsync(Arg.Any<string>(), Arg.Any<MediaType?>(), Arg.Any<int?>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<MediaTitleAlias>());
+        _detailsRepo.GetByMediaIdsAsync(Arg.Any<IReadOnlyList<int>>(), Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<int, ImdbTitleDetails>
+            {
+                [1] = new() { MediaId = 1, Tconst = "tt0903747" },
+                [2] = new() { MediaId = 2, Tconst = "tt9999999" }
+            });
+
+        _normalizer.ComputeSimilarity("Breaking Bad", "Breaking Bad").Returns(1.0m);
+        _normalizer.ComputeSimilarity("Breaking Bad", "Breaking Badly").Returns(0.85m);
+
+        var result = await _sut.SearchByTitleAsync("Breaking Bad");
+
+        result.Should().HaveCount(2);
+        result[0].ConfidenceScore.Should().BeGreaterThan(result[1].ConfidenceScore);
+        result[0].ExternalId.Should().Be("tt0903747");
+    }
+
+    [Fact]
+    public async Task SearchByTitleAsync_NoImdbDetails_SkipsTitle()
+    {
+        SetupNormalizer();
+
+        var title = CreateMediaTitle(1, "NoDetails Movie", 2020, MediaType.Movie);
+        _titleRepo.SearchByTitleAsync(Arg.Any<string>(), Arg.Any<MediaType?>(), Arg.Any<int?>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new[] { title });
+        _titleRepo.SearchByAliasAsync(Arg.Any<string>(), Arg.Any<MediaType?>(), Arg.Any<int?>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<MediaTitleAlias>());
+        _detailsRepo.GetByMediaIdsAsync(Arg.Any<IReadOnlyList<int>>(), Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<int, ImdbTitleDetails>());
+
+        var result = await _sut.SearchByTitleAsync("NoDetails Movie");
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task SearchByTitleAsync_DuplicateFromCanonicalAndAlias_KeepsBestScore()
+    {
+        SetupNormalizer();
+
+        var title = CreateMediaTitle(1, "Inception", 2010, MediaType.Movie);
+        var alias = new MediaTitleAlias { AliasId = 1, MediaId = 1, AliasTitle = "Inception", MediaTitle = title };
+
+        _titleRepo.SearchByTitleAsync(Arg.Any<string>(), Arg.Any<MediaType?>(), Arg.Any<int?>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new[] { title });
+        _titleRepo.SearchByAliasAsync(Arg.Any<string>(), Arg.Any<MediaType?>(), Arg.Any<int?>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new[] { alias });
+        _detailsRepo.GetByMediaIdsAsync(Arg.Any<IReadOnlyList<int>>(), Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<int, ImdbTitleDetails>
+            {
+                [1] = new() { MediaId = 1, Tconst = "tt1375666" }
+            });
+
+        _normalizer.ComputeSimilarity("Inception", "Inception").Returns(1.0m);
+
+        var result = await _sut.SearchByTitleAsync("Inception");
+
+        result.Should().HaveCount(1);
+        result[0].ConfidenceScore.Should().Be(1.0m);
+    }
+
+    [Fact]
+    public async Task SearchByTitleAsync_NoCandidatesFromEither_ReturnsEmpty()
+    {
+        SetupNormalizer();
+
+        _titleRepo.SearchByTitleAsync(Arg.Any<string>(), Arg.Any<MediaType?>(), Arg.Any<int?>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<MediaTitle>());
+        _titleRepo.SearchByAliasAsync(Arg.Any<string>(), Arg.Any<MediaType?>(), Arg.Any<int?>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<MediaTitleAlias>());
+
+        var result = await _sut.SearchByTitleAsync("Nonexistent");
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task SearchByTitleAsync_YearBonusCappedAt1()
+    {
+        SetupNormalizer();
+
+        var title = CreateMediaTitle(1, "Movie", 2020, MediaType.Movie);
+        _titleRepo.SearchByTitleAsync(Arg.Any<string>(), Arg.Any<MediaType?>(), Arg.Any<int?>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new[] { title });
+        _titleRepo.SearchByAliasAsync(Arg.Any<string>(), Arg.Any<MediaType?>(), Arg.Any<int?>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<MediaTitleAlias>());
+        _detailsRepo.GetByMediaIdsAsync(Arg.Any<IReadOnlyList<int>>(), Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<int, ImdbTitleDetails>
+            {
+                [1] = new() { MediaId = 1, Tconst = "tt1111111" }
+            });
+
+        _normalizer.ComputeSimilarity("Movie", "Movie").Returns(0.98m);
+
+        var result = await _sut.SearchByTitleAsync("Movie", year: 2020);
+
+        result.Should().HaveCount(1);
+        result[0].ConfidenceScore.Should().Be(1.0m);
+    }
+
+    // ── SearchByExternalIdAsync ────────────────────────────────────
+
+    [Fact]
+    public async Task SearchByExternalIdAsync_NullId_ReturnsNull()
+    {
+        var result = await _sut.SearchByExternalIdAsync(null!);
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SearchByExternalIdAsync_EmptyId_ReturnsNull()
+    {
+        var result = await _sut.SearchByExternalIdAsync("");
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SearchByExternalIdAsync_ValidTconst_ReturnsResult()
+    {
+        var details = new ImdbTitleDetails { MediaId = 1, Tconst = "tt0133093" };
+        var title = CreateMediaTitle(1, "The Matrix", 1999, MediaType.Movie);
+
+        _detailsRepo.GetByTconstAsync("tt0133093", Arg.Any<CancellationToken>()).Returns(details);
+        _titleRepo.GetByIdAsync(1, Arg.Any<CancellationToken>()).Returns(title);
+
+        var result = await _sut.SearchByExternalIdAsync("tt0133093");
+
+        result.Should().NotBeNull();
+        result!.CanonicalTitle.Should().Be("The Matrix");
+        result.Year.Should().Be(1999);
+        result.Type.Should().Be("movie");
+        result.ConfidenceScore.Should().Be(1.0m);
+        result.ExternalId.Should().Be("tt0133093");
+    }
+
+    [Fact]
+    public async Task SearchByExternalIdAsync_TconstNotFound_ReturnsNull()
+    {
+        _detailsRepo.GetByTconstAsync("tt0000000", Arg.Any<CancellationToken>()).ReturnsNull();
+
+        var result = await _sut.SearchByExternalIdAsync("tt0000000");
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SearchByExternalIdAsync_TitleNotFound_ReturnsNull()
+    {
+        var details = new ImdbTitleDetails { MediaId = 999, Tconst = "tt0000001" };
+        _detailsRepo.GetByTconstAsync("tt0000001", Arg.Any<CancellationToken>()).Returns(details);
+        _titleRepo.GetByIdAsync(999, Arg.Any<CancellationToken>()).ReturnsNull();
+
+        var result = await _sut.SearchByExternalIdAsync("tt0000001");
+
+        result.Should().BeNull();
+    }
+
+    // ── GetEpisodeListAsync ────────────────────────────────────────
+
+    [Fact]
+    public async Task GetEpisodeListAsync_ReturnsEpisodes()
+    {
+        var episodes = new List<MediaEpisode>
+        {
+            new() { EpisodeId = 1, MediaId = 1, Season = 1, EpisodeNumber = 1 },
+            new() { EpisodeId = 2, MediaId = 1, Season = 1, EpisodeNumber = 2 },
+            new() { EpisodeId = 3, MediaId = 1, Season = 2, EpisodeNumber = 1 }
+        };
+
+        _episodeRepo.GetByMediaIdAsync(1, Arg.Any<CancellationToken>()).Returns(episodes);
+
+        var result = await _sut.GetEpisodeListAsync(1);
+
+        result.Should().HaveCount(3);
+        result[0].Season.Should().Be(1);
+        result[0].EpisodeNumber.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetEpisodeListAsync_WithSeasonFilter_FiltersCorrectly()
+    {
+        var episodes = new List<MediaEpisode>
+        {
+            new() { EpisodeId = 1, MediaId = 1, Season = 1, EpisodeNumber = 1 },
+            new() { EpisodeId = 2, MediaId = 1, Season = 1, EpisodeNumber = 2 },
+            new() { EpisodeId = 3, MediaId = 1, Season = 2, EpisodeNumber = 1 }
+        };
+
+        _episodeRepo.GetByMediaIdAsync(1, Arg.Any<CancellationToken>()).Returns(episodes);
+
+        var result = await _sut.GetEpisodeListAsync(1, season: 1);
+
+        result.Should().HaveCount(2);
+        result.Should().OnlyContain(e => e.Season == 1);
+    }
+
+    [Fact]
+    public async Task GetEpisodeListAsync_NoEpisodes_ReturnsEmpty()
+    {
+        _episodeRepo.GetByMediaIdAsync(1, Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<MediaEpisode>());
+
+        var result = await _sut.GetEpisodeListAsync(1);
+
+        result.Should().BeEmpty();
+    }
+
+    // ── GetRatingsAsync ────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetRatingsAsync_RatingExists_ReturnsRatingInfo()
+    {
+        var rating = new MediaRating { MediaId = 1, SourceId = 1, Rating = 8.7m, VoteCount = 2000000 };
+        _ratingRepo.GetByMediaIdAndSourceAsync(1, ImdbMetadataSource.ImdbSourceId, Arg.Any<CancellationToken>())
+            .Returns(rating);
+
+        var result = await _sut.GetRatingsAsync(1);
+
+        result.Should().NotBeNull();
+        result!.Rating.Should().Be(8.7m);
+        result.VoteCount.Should().Be(2000000);
+    }
+
+    [Fact]
+    public async Task GetRatingsAsync_NoRating_ReturnsNull()
+    {
+        _ratingRepo.GetByMediaIdAndSourceAsync(1, ImdbMetadataSource.ImdbSourceId, Arg.Any<CancellationToken>())
+            .ReturnsNull();
+
+        var result = await _sut.GetRatingsAsync(1);
+
+        result.Should().BeNull();
+    }
+
+    // ── ParseMediaType ─────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData("", null)]
+    [InlineData("movie", MediaType.Movie)]
+    [InlineData("Movie", MediaType.Movie)]
+    [InlineData("MOVIE", MediaType.Movie)]
+    [InlineData("series", MediaType.Series)]
+    [InlineData("episode", MediaType.Episode)]
+    [InlineData("unknown", null)]
+    public void ParseMediaType_ReturnsExpected(string? input, MediaType? expected)
+    {
+        ImdbMetadataSource.ParseMediaType(input).Should().Be(expected);
+    }
+
+    // ── MediaTypeToString ──────────────────────────────────────────
+
+    [Theory]
+    [InlineData(MediaType.Movie, "movie")]
+    [InlineData(MediaType.Series, "series")]
+    [InlineData(MediaType.Episode, "episode")]
+    public void MediaTypeToString_ReturnsExpected(MediaType input, string expected)
+    {
+        ImdbMetadataSource.MediaTypeToString(input).Should().Be(expected);
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────
+
+    private void SetupNormalizer()
+    {
+        _normalizer.Normalize(Arg.Any<string>())
+            .Returns(callInfo => callInfo.Arg<string>()?.ToLowerInvariant() ?? "");
+    }
+
+    private static MediaTitle CreateMediaTitle(int id, string title, int? year, MediaType type)
+    {
+        return new MediaTitle
+        {
+            MediaId = id,
+            CanonicalTitle = title,
+            Year = year,
+            Type = type,
+            SourceId = 1,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+    }
+}


### PR DESCRIPTION
Closes #23

## Summary

Implements the IMDB matching engine that matches scraped forum content against imported IMDB data. Implements \IMetadataSource\ for IMDB.

### Components

**Domain Interfaces** (5 new):
- \ITitleNormalizer\ — title normalization and fuzzy similarity contract
- \IMediaTitleRepository\ — title/alias search repository
- \IMediaRatingRepository\ — rating lookup repository
- \IImdbTitleDetailsRepository\ — IMDB-specific details repository
- \IImdbMatchingService\ — high-level matching orchestration contract

**Application Services** (2 new):
- \TitleNormalizer\ — strips diacritics, lowercases, removes punctuation, extracts years, Levenshtein-based fuzzy similarity
- \ImdbMatchingService\ — parses scraped titles, extracts embedded years, delegates to IMetadataSource, applies confidence threshold (0.5)

**Infrastructure** (4 new):
- \ImdbMetadataSource\ — full IMetadataSource implementation for IMDB:
  - Fuzzy title matching against MediaTitle + MediaTitleAlias
  - Confidence scoring: year bonus (+0.05), alias penalty (-0.02), deduplication, capped at 1.0
  - SearchByExternalId (tconst lookup), GetEpisodeList, GetRatings
- \MediaTitleRepository\, \MediaRatingRepository\, \ImdbTitleDetailsRepository\ — EF Core implementations

**DI Registration**: All services registered in Program.cs

### Testing

95 new tests covering:
- Exact match, fuzzy match, no match, multiple matches
- Year filtering and year bonus
- Diacritics handling (Czech, French, etc.)
- Alias matching with penalty
- Deduplication (canonical + alias for same title)
- Type filtering (movie, series, episode)
- Edge cases (null/empty input, missing IMDB details, below-threshold confidence)

**Total test count**: 701 (all passing)

### Known Limitations
- Title search uses SQL LOWER + LIKE (no full-text search or trigram index yet)
- Levenshtein similarity is computed in-memory after SQL candidate retrieval