### PR TITLE
feat(#13): Forum structure refresh scheduling

### DIFF
--- a/src/SeriesScraper.Infrastructure/BackgroundServices/ForumStructureRefreshService.cs
+++ b/src/SeriesScraper.Infrastructure/BackgroundServices/ForumStructureRefreshService.cs
@@ -1,0 +1,154 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using SeriesScraper.Domain.Entities;
+using SeriesScraper.Domain.Interfaces;
+
+namespace SeriesScraper.Infrastructure.BackgroundServices;
+
+/// <summary>
+/// Background service that periodically refreshes forum structure (sections) for all active forums.
+/// Uses PeriodicTimer per research issue #7.
+/// Issue #13: Structure refresh scheduling.
+/// </summary>
+public class ForumStructureRefreshService : BackgroundService
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<ForumStructureRefreshService> _logger;
+    internal const string SettingKey = "ForumRefreshIntervalHours";
+    internal const int DefaultIntervalHours = 24;
+
+    public ForumStructureRefreshService(
+        IServiceProvider serviceProvider,
+        ILogger<ForumStructureRefreshService> logger)
+    {
+        _serviceProvider = serviceProvider;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("Forum Structure Refresh Service starting");
+
+        // Run initial refresh on startup
+        await RefreshAllForumsAsync(stoppingToken);
+
+        // Then run on configurable schedule
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            var intervalHours = await GetRefreshIntervalAsync(stoppingToken);
+            var interval = TimeSpan.FromHours(intervalHours);
+
+            _logger.LogInformation("Next forum structure refresh scheduled in {Interval}", interval);
+
+            using var timer = new PeriodicTimer(interval);
+
+            try
+            {
+                if (await timer.WaitForNextTickAsync(stoppingToken))
+                {
+                    await RefreshAllForumsAsync(stoppingToken);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // Normal shutdown
+                break;
+            }
+        }
+
+        _logger.LogInformation("Forum Structure Refresh Service stopping");
+    }
+
+    internal async Task RefreshAllForumsAsync(CancellationToken ct)
+    {
+        _logger.LogInformation("Starting forum structure refresh for all active forums");
+
+        IReadOnlyList<Forum> forums;
+        using (var scope = _serviceProvider.CreateScope())
+        {
+            var forumRepository = scope.ServiceProvider.GetRequiredService<IForumRepository>();
+            forums = await forumRepository.GetActiveAsync(ct);
+        }
+
+        _logger.LogInformation("Found {ForumCount} active forums to refresh", forums.Count);
+
+        var newTotal = 0;
+        var removedTotal = 0;
+        var updatedTotal = 0;
+        var failedForums = 0;
+
+        foreach (var forum in forums)
+        {
+            try
+            {
+                using var scope = _serviceProvider.CreateScope();
+                var discoveryService = scope.ServiceProvider
+                    .GetRequiredService<IForumSectionDiscoveryService>();
+                var sectionRepository = scope.ServiceProvider
+                    .GetRequiredService<IForumSectionRepository>();
+
+                // Get existing active sections before refresh
+                var existingBefore = await sectionRepository.GetByForumIdAsync(forum.ForumId, ct);
+                var existingActiveUrls = existingBefore
+                    .Where(s => s.IsActive)
+                    .Select(s => s.Url)
+                    .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+                // Run discovery (handles add/update/deactivate internally)
+                var discoveredSections = await discoveryService.DiscoverSectionsAsync(forum, ct);
+
+                // Calculate change deltas for logging
+                var discoveredUrls = discoveredSections
+                    .Select(s => s.Url)
+                    .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+                var newSections = discoveredUrls.Except(existingActiveUrls).Count();
+                var removedSections = existingActiveUrls.Except(discoveredUrls).Count();
+                var updatedSections = discoveredUrls.Intersect(existingActiveUrls).Count();
+
+                newTotal += newSections;
+                removedTotal += removedSections;
+                updatedTotal += updatedSections;
+
+                _logger.LogInformation(
+                    "Forum {ForumId} ({ForumName}) refresh complete: {New} new, {Updated} updated, {Removed} removed sections",
+                    forum.ForumId, forum.Name, newSections, updatedSections, removedSections);
+            }
+            catch (Exception ex)
+            {
+                failedForums++;
+                _logger.LogError(ex,
+                    "Forum structure refresh failed for forum {ForumId} ({ForumName}), continuing with remaining forums",
+                    forum.ForumId, forum.Name);
+                // Continue with other forums — one failure must not stop the rest
+            }
+        }
+
+        _logger.LogInformation(
+            "Forum structure refresh complete: {New} new, {Updated} updated, {Removed} removed sections across {ForumCount} forums ({Failed} failed)",
+            newTotal, updatedTotal, removedTotal, forums.Count, failedForums);
+    }
+
+    internal async Task<int> GetRefreshIntervalAsync(CancellationToken ct)
+    {
+        try
+        {
+            using var scope = _serviceProvider.CreateScope();
+            var settingRepository = scope.ServiceProvider
+                .GetRequiredService<ISettingRepository>();
+            var value = await settingRepository.GetValueAsync(SettingKey, ct);
+
+            if (value != null && int.TryParse(value, out var hours) && hours > 0)
+            {
+                return hours;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to read refresh interval from settings, using default");
+        }
+
+        return DefaultIntervalHours;
+    }
+}

--- a/src/SeriesScraper.Web/Program.cs
+++ b/src/SeriesScraper.Web/Program.cs
@@ -6,6 +6,7 @@ using SeriesScraper.Application.Services;
 using SeriesScraper.Domain.Interfaces;
 using SeriesScraper.Infrastructure.Data;
 using SeriesScraper.Infrastructure.Repositories;
+using SeriesScraper.Infrastructure.BackgroundServices;
 using SeriesScraper.Infrastructure.Services;
 using SeriesScraper.Infrastructure.Services.Imdb;
 using SeriesScraper.Web.BackgroundServices;
@@ -99,8 +100,9 @@ try
     builder.Services.AddScoped<ISettingRepository, SettingRepository>();
     builder.Services.AddScoped<IDataSourceImportRunRepository, DataSourceImportRunRepository>();
 
-    // Background service
+    // Background services
     builder.Services.AddHostedService<ScrapeRunBackgroundService>();
+    builder.Services.AddHostedService<ForumStructureRefreshService>();
 
     // Security services (#45, #46)
     builder.Services.AddSingleton<ISanitizer, HtmlContentSanitizer>();

--- a/tests/SeriesScraper.Infrastructure.Tests/BackgroundServices/ForumStructureRefreshServiceTests.cs
+++ b/tests/SeriesScraper.Infrastructure.Tests/BackgroundServices/ForumStructureRefreshServiceTests.cs
@@ -1,0 +1,346 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using SeriesScraper.Domain.Entities;
+using SeriesScraper.Domain.Interfaces;
+using SeriesScraper.Infrastructure.BackgroundServices;
+
+namespace SeriesScraper.Infrastructure.Tests.BackgroundServices;
+
+public class ForumStructureRefreshServiceTests
+{
+    private readonly IForumRepository _forumRepository = Substitute.For<IForumRepository>();
+    private readonly IForumSectionDiscoveryService _discoveryService = Substitute.For<IForumSectionDiscoveryService>();
+    private readonly IForumSectionRepository _sectionRepository = Substitute.For<IForumSectionRepository>();
+    private readonly ISettingRepository _settingRepository = Substitute.For<ISettingRepository>();
+
+    private Forum CreateForum(int id = 1, string name = "TestForum") => new()
+    {
+        ForumId = id,
+        Name = name,
+        BaseUrl = $"https://forum{id}.example.com",
+        Username = "user",
+        CredentialKey = "TEST_PASS",
+        IsActive = true,
+        CrawlDepth = 1
+    };
+
+    private ForumSection CreateSection(int sectionId, int forumId, string url, string name, bool isActive = true) => new()
+    {
+        SectionId = sectionId,
+        ForumId = forumId,
+        Url = url,
+        Name = name,
+        IsActive = isActive,
+        LastCrawledAt = DateTime.UtcNow
+    };
+
+    // --- ExecuteAsync / startup tests ---
+
+    [Fact]
+    public async Task ExecuteAsync_RunsInitialRefreshOnStart()
+    {
+        var refreshCalled = new TaskCompletionSource<bool>();
+        var forum = CreateForum();
+        _forumRepository.GetActiveAsync(Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                refreshCalled.TrySetResult(true);
+                return new List<Forum> { forum }.AsReadOnly();
+            });
+        _sectionRepository.GetByForumIdAsync(forum.ForumId, Arg.Any<CancellationToken>())
+            .Returns(new List<ForumSection>().AsReadOnly());
+        _discoveryService.DiscoverSectionsAsync(forum, Arg.Any<CancellationToken>())
+            .Returns(new List<ForumSection>().AsReadOnly());
+
+        var service = CreateService();
+        using var cts = new CancellationTokenSource();
+
+        await service.StartAsync(cts.Token);
+        var wasCalled = await refreshCalled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        cts.Cancel();
+        await service.StopAsync(CancellationToken.None);
+
+        wasCalled.Should().BeTrue();
+        await _forumRepository.Received().GetActiveAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_StopsGracefullyOnCancellation()
+    {
+        _forumRepository.GetActiveAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<Forum>().AsReadOnly());
+
+        var service = CreateService();
+        using var cts = new CancellationTokenSource();
+
+        await service.StartAsync(cts.Token);
+        await Task.Delay(200);
+        cts.Cancel();
+
+        var act = async () => await service.StopAsync(CancellationToken.None);
+        await act.Should().NotThrowAsync();
+    }
+
+    // --- RefreshAllForumsAsync tests ---
+
+    [Fact]
+    public async Task RefreshAllForumsAsync_CallsDiscoveryForEachActiveForum()
+    {
+        var forum1 = CreateForum(1, "Forum1");
+        var forum2 = CreateForum(2, "Forum2");
+        _forumRepository.GetActiveAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<Forum> { forum1, forum2 }.AsReadOnly());
+        _sectionRepository.GetByForumIdAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new List<ForumSection>().AsReadOnly());
+        _discoveryService.DiscoverSectionsAsync(Arg.Any<Forum>(), Arg.Any<CancellationToken>())
+            .Returns(new List<ForumSection>().AsReadOnly());
+
+        var service = CreateService();
+        await service.RefreshAllForumsAsync(CancellationToken.None);
+
+        await _discoveryService.Received(1).DiscoverSectionsAsync(forum1, Arg.Any<CancellationToken>());
+        await _discoveryService.Received(1).DiscoverSectionsAsync(forum2, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RefreshAllForumsAsync_ContinuesWhenOneForumFails()
+    {
+        var forum1 = CreateForum(1, "FailForum");
+        var forum2 = CreateForum(2, "SuccessForum");
+        _forumRepository.GetActiveAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<Forum> { forum1, forum2 }.AsReadOnly());
+
+        _sectionRepository.GetByForumIdAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new List<ForumSection>().AsReadOnly());
+
+        // First forum throws, second succeeds
+        _discoveryService.DiscoverSectionsAsync(forum1, Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("Network error"));
+        _discoveryService.DiscoverSectionsAsync(forum2, Arg.Any<CancellationToken>())
+            .Returns(new List<ForumSection>().AsReadOnly());
+
+        var service = CreateService();
+
+        var act = async () => await service.RefreshAllForumsAsync(CancellationToken.None);
+        await act.Should().NotThrowAsync();
+
+        // Second forum should still have been processed
+        await _discoveryService.Received(1).DiscoverSectionsAsync(forum2, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RefreshAllForumsAsync_NoForums_CompletesWithoutError()
+    {
+        _forumRepository.GetActiveAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<Forum>().AsReadOnly());
+
+        var service = CreateService();
+
+        var act = async () => await service.RefreshAllForumsAsync(CancellationToken.None);
+        await act.Should().NotThrowAsync();
+
+        await _discoveryService.DidNotReceive()
+            .DiscoverSectionsAsync(Arg.Any<Forum>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RefreshAllForumsAsync_LogsNewSections()
+    {
+        var forum = CreateForum();
+        _forumRepository.GetActiveAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<Forum> { forum }.AsReadOnly());
+
+        // No existing sections
+        _sectionRepository.GetByForumIdAsync(forum.ForumId, Arg.Any<CancellationToken>())
+            .Returns(new List<ForumSection>().AsReadOnly());
+
+        // Discovery finds new sections
+        var newSection = CreateSection(1, forum.ForumId, "https://forum1.example.com/section1", "New Section");
+        _discoveryService.DiscoverSectionsAsync(forum, Arg.Any<CancellationToken>())
+            .Returns(new List<ForumSection> { newSection }.AsReadOnly());
+
+        var service = CreateService();
+
+        // Should complete without error — logging is internal
+        var act = async () => await service.RefreshAllForumsAsync(CancellationToken.None);
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task RefreshAllForumsAsync_LogsRemovedSections()
+    {
+        var forum = CreateForum();
+        _forumRepository.GetActiveAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<Forum> { forum }.AsReadOnly());
+
+        // Existing active section
+        var existingSection = CreateSection(1, forum.ForumId, "https://forum1.example.com/old", "Old Section");
+        _sectionRepository.GetByForumIdAsync(forum.ForumId, Arg.Any<CancellationToken>())
+            .Returns(new List<ForumSection> { existingSection }.AsReadOnly());
+
+        // Discovery finds nothing (old section was removed)
+        _discoveryService.DiscoverSectionsAsync(forum, Arg.Any<CancellationToken>())
+            .Returns(new List<ForumSection>().AsReadOnly());
+
+        var service = CreateService();
+
+        var act = async () => await service.RefreshAllForumsAsync(CancellationToken.None);
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task RefreshAllForumsAsync_LogsUpdatedSections()
+    {
+        var forum = CreateForum();
+        _forumRepository.GetActiveAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<Forum> { forum }.AsReadOnly());
+
+        var existingSection = CreateSection(1, forum.ForumId, "https://forum1.example.com/s1", "Section");
+        _sectionRepository.GetByForumIdAsync(forum.ForumId, Arg.Any<CancellationToken>())
+            .Returns(new List<ForumSection> { existingSection }.AsReadOnly());
+
+        // Same URL returned = updated (not new or removed)
+        var updatedSection = CreateSection(1, forum.ForumId, "https://forum1.example.com/s1", "Section Updated");
+        _discoveryService.DiscoverSectionsAsync(forum, Arg.Any<CancellationToken>())
+            .Returns(new List<ForumSection> { updatedSection }.AsReadOnly());
+
+        var service = CreateService();
+
+        var act = async () => await service.RefreshAllForumsAsync(CancellationToken.None);
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task RefreshAllForumsAsync_AllForumsFail_CompletesWithoutThrowing()
+    {
+        var forum1 = CreateForum(1, "Fail1");
+        var forum2 = CreateForum(2, "Fail2");
+        _forumRepository.GetActiveAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<Forum> { forum1, forum2 }.AsReadOnly());
+
+        _sectionRepository.GetByForumIdAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new List<ForumSection>().AsReadOnly());
+
+        _discoveryService.DiscoverSectionsAsync(Arg.Any<Forum>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("Total failure"));
+
+        var service = CreateService();
+
+        var act = async () => await service.RefreshAllForumsAsync(CancellationToken.None);
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task RefreshAllForumsAsync_SkipsInactiveSectionsInDelta()
+    {
+        var forum = CreateForum();
+        _forumRepository.GetActiveAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<Forum> { forum }.AsReadOnly());
+
+        // Existing inactive section should not count in delta
+        var inactiveSection = CreateSection(1, forum.ForumId, "https://forum1.example.com/inactive", "Inactive", isActive: false);
+        _sectionRepository.GetByForumIdAsync(forum.ForumId, Arg.Any<CancellationToken>())
+            .Returns(new List<ForumSection> { inactiveSection }.AsReadOnly());
+
+        _discoveryService.DiscoverSectionsAsync(forum, Arg.Any<CancellationToken>())
+            .Returns(new List<ForumSection>().AsReadOnly());
+
+        var service = CreateService();
+
+        var act = async () => await service.RefreshAllForumsAsync(CancellationToken.None);
+        await act.Should().NotThrowAsync();
+    }
+
+    // --- GetRefreshIntervalAsync tests ---
+
+    [Fact]
+    public async Task GetRefreshIntervalAsync_ReturnsConfiguredValue()
+    {
+        _settingRepository.GetValueAsync(ForumStructureRefreshService.SettingKey, Arg.Any<CancellationToken>())
+            .Returns("12");
+
+        var service = CreateService();
+        var result = await service.GetRefreshIntervalAsync(CancellationToken.None);
+
+        result.Should().Be(12);
+    }
+
+    [Fact]
+    public async Task GetRefreshIntervalAsync_ReturnsDefault_WhenNoSetting()
+    {
+        _settingRepository.GetValueAsync(ForumStructureRefreshService.SettingKey, Arg.Any<CancellationToken>())
+            .Returns((string?)null);
+
+        var service = CreateService();
+        var result = await service.GetRefreshIntervalAsync(CancellationToken.None);
+
+        result.Should().Be(ForumStructureRefreshService.DefaultIntervalHours);
+    }
+
+    [Fact]
+    public async Task GetRefreshIntervalAsync_ReturnsDefault_WhenInvalidSetting()
+    {
+        _settingRepository.GetValueAsync(ForumStructureRefreshService.SettingKey, Arg.Any<CancellationToken>())
+            .Returns("not_a_number");
+
+        var service = CreateService();
+        var result = await service.GetRefreshIntervalAsync(CancellationToken.None);
+
+        result.Should().Be(ForumStructureRefreshService.DefaultIntervalHours);
+    }
+
+    [Fact]
+    public async Task GetRefreshIntervalAsync_ReturnsDefault_WhenNegativeValue()
+    {
+        _settingRepository.GetValueAsync(ForumStructureRefreshService.SettingKey, Arg.Any<CancellationToken>())
+            .Returns("-5");
+
+        var service = CreateService();
+        var result = await service.GetRefreshIntervalAsync(CancellationToken.None);
+
+        result.Should().Be(ForumStructureRefreshService.DefaultIntervalHours);
+    }
+
+    [Fact]
+    public async Task GetRefreshIntervalAsync_ReturnsDefault_WhenZeroValue()
+    {
+        _settingRepository.GetValueAsync(ForumStructureRefreshService.SettingKey, Arg.Any<CancellationToken>())
+            .Returns("0");
+
+        var service = CreateService();
+        var result = await service.GetRefreshIntervalAsync(CancellationToken.None);
+
+        result.Should().Be(ForumStructureRefreshService.DefaultIntervalHours);
+    }
+
+    [Fact]
+    public async Task GetRefreshIntervalAsync_ReturnsDefault_WhenRepositoryThrows()
+    {
+        _settingRepository.GetValueAsync(ForumStructureRefreshService.SettingKey, Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("DB down"));
+
+        var service = CreateService();
+        var result = await service.GetRefreshIntervalAsync(CancellationToken.None);
+
+        result.Should().Be(ForumStructureRefreshService.DefaultIntervalHours);
+    }
+
+    // --- Helper ---
+
+    private ForumStructureRefreshService CreateService()
+    {
+        var services = new ServiceCollection();
+        services.AddScoped(_ => _forumRepository);
+        services.AddScoped(_ => _discoveryService);
+        services.AddScoped(_ => _sectionRepository);
+        services.AddScoped(_ => _settingRepository);
+
+        var provider = services.BuildServiceProvider();
+        return new ForumStructureRefreshService(
+            provider,
+            NullLogger<ForumStructureRefreshService>.Instance);
+    }
+}


### PR DESCRIPTION
Closes #13

## Summary of Changes

Implements periodic forum structure refresh using the PeriodicTimer pattern (research #7), following the same approach as ImdbImportBackgroundService.

### New Files
- **Infrastructure**: \ForumStructureRefreshService\ — BackgroundService that periodically refreshes forum sections for all active forums
- **Tests**: \ForumStructureRefreshServiceTests\ — 16 tests covering all behaviour

### Modified Files
- **Web**: \Program.cs\ — registered \ForumStructureRefreshService\ as hosted service, registered \ISettingRepository\ → \SettingRepository\ (scoped)

### Features
- **Startup refresh**: Runs initial section discovery for all active forums on app start
- **Scheduled refresh**: Configurable interval via \ForumRefreshIntervalHours\ setting (default: 24h)
- **Per-forum isolation**: If one forum fails, remaining forums continue processing
- **Change logging**: Logs new/updated/removed section counts per forum and totals
- **Settings**: Uses \ISettingRepository\ for interval config (falls back to default on invalid/missing/error)

### DI Registration
- \ForumStructureRefreshService\ (hosted service)
- \ISettingRepository\ → \SettingRepository\ (scoped)

## Testing Notes
- 16 new ForumStructureRefreshServiceTests (all pass)
- Full suite: 1,141 tests, 0 failures
- Build succeeds with no new warnings

## Known Limitations
- Interval is re-read each cycle (supports runtime changes without restart)
- PeriodicTimer recreated each cycle to pick up setting changes (same pattern as ImdbImportBackgroundService)