### PR TITLE
fix(#81): Fix Docker container build and startup failures

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,21 @@
+# Ignore local build artifacts so Docker build context stays clean
+# and Windows-generated obj/ files don't overwrite the Linux restore.
+**/bin/
+**/obj/
+
+# Git / IDE
+.git/
+.vs/
+*.user
+.idea/
+
+# Secrets
+.env
+
+# Docker files (not needed inside image)
+docker-compose*.yml
+Dockerfile
+
+# Logs
+*.log
+**/logs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ WORKDIR /app
 EXPOSE 8080
 
 # Install curl for health checks (health check uses curl -f http://localhost:8080/healthz)
-RUN apk add --no-cache curl
+RUN apk add --no-cache curl icu-libs
 
 ENV ASPNETCORE_URLS=http://+:8080
 ENV DOTNET_RUNNING_IN_CONTAINER=true
@@ -52,8 +52,7 @@ COPY . .
 WORKDIR "/src/src/SeriesScraper.Web"
 RUN dotnet build "SeriesScraper.Web.csproj" \
     --configuration Release \
-    --no-restore \
-    --output /app/build
+    --no-restore
 
 # ─── Publish Image ─────────────────────────────────────────────────────────
 FROM build AS publish

--- a/src/SeriesScraper.Web/Program.cs
+++ b/src/SeriesScraper.Web/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.EntityFrameworkCore;
 using Serilog;
 using SeriesScraper.Application.Security;
 using SeriesScraper.Application.Services;
@@ -35,10 +36,15 @@ try
             .Enrich.FromLogContext();
     });
 
+    // Database
+    builder.Services.AddDbContext<AppDbContext>(options =>
+        options.UseNpgsql(builder.Configuration.GetConnectionString("DefaultConnection")));
+
     // Add services to the container.
     builder.Services.AddRazorPages();
     builder.Services.AddServerSideBlazor();
     builder.Services.AddSingleton<WeatherForecastService>();
+    builder.Services.AddHealthChecks();
 
     // Antiforgery for any HTTP POST endpoints (#47)
     builder.Services.AddAntiforgery();
@@ -110,6 +116,13 @@ try
 
     var app = builder.Build();
 
+    // Apply EF Core migrations on startup
+    using (var scope = app.Services.CreateScope())
+    {
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        await db.Database.MigrateAsync();
+    }
+
     // Serilog request logging middleware
     app.UseSerilogRequestLogging(options =>
     {
@@ -137,6 +150,7 @@ try
     // Antiforgery middleware for CSRF protection on any non-Blazor POST endpoints (#47)
     app.UseAntiforgery();
 
+    app.MapHealthChecks("/healthz");
     app.MapBlazorHub();
     app.MapFallbackToPage("/_Host");
 


### PR DESCRIPTION
## Summary

Closes #81

The application failed to start in Docker due to multiple compounding issues across the build and runtime stages. This PR fixes all six root causes:

1. **Add `.dockerignore`** — Windows `obj/` directories containing Windows-path `project.assets.json` files were copied into the build context, overwriting Linux-generated restore artifacts and causing NuGet fallback folder errors during build.

2. **Remove `--output /app/build` from `dotnet build`** — The custom output directory caused `dotnet publish --no-build` to fail because it looked for build artifacts in `bin/Release/net8.0/` (the default location), not `/app/build`.

3. **Add `icu-libs` to Alpine runtime image** — The environment sets `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false`, which requires ICU libraries. Alpine does not include these by default, causing a runtime crash.

4. **Register `AppDbContext` in DI** — `AppDbContext` was never registered with `AddDbContext<>()`, so any resolution of repositories depending on it threw `InvalidOperationException` and crashed the host immediately on startup.

5. **Add EF Core auto-migration on startup** — Calls `db.Database.MigrateAsync()` so the database schema is applied automatically when the container starts, without requiring a manual migration step.

6. **Map `/healthz` health check endpoint** — The Docker Compose health check calls `curl -f http://localhost:8080/healthz`, but no such endpoint was mapped. Added `AddHealthChecks()` and `MapHealthChecks("/healthz")`.

## Files changed

- `.dockerignore` (new)
- `Dockerfile`
- `src/SeriesScraper.Web/Program.cs`

## Test plan

- [ ] `docker compose build` completes without errors
- [ ] `docker compose up` starts the application successfully
- [ ] `curl http://localhost:8080/healthz` returns 200
- [ ] Application connects to PostgreSQL and applies migrations
- [ ] Blazor UI loads in browser at http://localhost:8080

🤖 Generated with [Claude Code](https://claude.com/claude-code)