### PR TITLE
fix(#51): Enforce credential key validation at all entry points

### DIFF
--- a/src/SeriesScraper.Application/Services/ForumCredentialService.cs
+++ b/src/SeriesScraper.Application/Services/ForumCredentialService.cs
@@ -29,7 +29,9 @@ public class ForumCredentialService : IForumCredentialService
             if (!isActive)
                 continue;
 
-            var envValue = Environment.GetEnvironmentVariable(credentialKey);
+            // Validate key format before reading env var (security requirement #51)
+            var key = new CredentialKey(credentialKey);
+            var envValue = Environment.GetEnvironmentVariable(key.Value);
             if (string.IsNullOrEmpty(envValue))
             {
                 missing.Add((forumName, credentialKey));

--- a/src/SeriesScraper.Domain/Entities/Forum.cs
+++ b/src/SeriesScraper.Domain/Entities/Forum.cs
@@ -1,4 +1,5 @@
 using SeriesScraper.Domain.Enums;
+using SeriesScraper.Domain.ValueObjects;
 
 namespace SeriesScraper.Domain.Entities;
 
@@ -8,6 +9,8 @@ namespace SeriesScraper.Domain.Entities;
 /// </summary>
 public class Forum
 {
+    private string _credentialKey = null!;
+
     public int ForumId { get; set; }
     public required string Name { get; set; }
     public required string BaseUrl { get; set; }
@@ -16,8 +19,17 @@ public class Forum
     /// <summary>
     /// Name of the environment variable containing the forum password.
     /// NEVER contains the actual password (security requirement).
+    /// Validated to match the FORUM_* pattern to prevent arbitrary env var reads (#51).
     /// </summary>
-    public required string CredentialKey { get; set; }
+    public required string CredentialKey
+    {
+        get => _credentialKey;
+        set
+        {
+            _ = new CredentialKey(value);
+            _credentialKey = value;
+        }
+    }
     
     public int CrawlDepth { get; set; } = 1;
     public int PolitenessDelayMs { get; set; } = 500;

--- a/tests/SeriesScraper.Application.Tests/Services/ForumCredentialServiceTests.cs
+++ b/tests/SeriesScraper.Application.Tests/Services/ForumCredentialServiceTests.cs
@@ -171,4 +171,48 @@ public class ForumCredentialServiceTests : IDisposable
         result.Should().HaveCount(1);
         result[0].ForumName.Should().Be("Empty Forum");
     }
+
+    // ── Attack scenario tests (Issue #51) ──────────────────────────────────
+
+    [Theory]
+    [InlineData("DB_PASSWORD")]
+    [InlineData("GITHUB_TOKEN")]
+    [InlineData("PATH")]
+    [InlineData("HOME")]
+    public void ResolveCredential_AttackScenario_ArbitraryEnvVar_Blocked(string maliciousKey)
+    {
+        var act = () => _sut.ResolveCredential(maliciousKey);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Theory]
+    [InlineData("DB_PASSWORD")]
+    [InlineData("GITHUB_TOKEN")]
+    [InlineData("PATH")]
+    public void ValidateActiveForumCredentials_InvalidKeyFormat_ThrowsArgumentException(string maliciousKey)
+    {
+        var forums = new List<(string, string, bool)>
+        {
+            ("Malicious Forum", maliciousKey, true),
+        };
+
+        var act = () => _sut.ValidateActiveForumCredentials(forums);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void ValidateActiveForumCredentials_InactiveInvalidKey_DoesNotThrow()
+    {
+        // Inactive forums should be skipped before key validation fires
+        var forums = new List<(string, string, bool)>
+        {
+            ("Inactive Forum", "DB_PASSWORD", false),
+        };
+
+        var act = () => _sut.ValidateActiveForumCredentials(forums);
+
+        act.Should().NotThrow();
+    }
 }

--- a/tests/SeriesScraper.Application.Tests/Services/RunProgressServiceTests.cs
+++ b/tests/SeriesScraper.Application.Tests/Services/RunProgressServiceTests.cs
@@ -39,7 +39,7 @@ public class RunProgressServiceTests
     [Fact]
     public async Task GetActiveRunsAsync_ReturnsMappedDtos_ForActiveRuns()
     {
-        var forum = new Forum { ForumId = 1, Name = "TestForum", BaseUrl = "https://example.com", Username = "user", CredentialKey = "ENV_KEY" };
+        var forum = new Forum { ForumId = 1, Name = "TestForum", BaseUrl = "https://example.com", Username = "user", CredentialKey = "FORUM_ENV_KEY" };
         var runs = new List<ScrapeRun>
         {
             CreateRun(1, 1, ScrapeRunStatus.Running, forum, totalItems: 10, processedItems: 5,
@@ -109,7 +109,7 @@ public class RunProgressServiceTests
     [Fact]
     public async Task GetActiveRunsAsync_MapsItemStatuses_Correctly()
     {
-        var forum = new Forum { ForumId = 1, Name = "F", BaseUrl = "https://x.com", Username = "u", CredentialKey = "K" };
+        var forum = new Forum { ForumId = 1, Name = "F", BaseUrl = "https://x.com", Username = "u", CredentialKey = "FORUM_K" };
         var run = CreateRun(1, 1, ScrapeRunStatus.Running, forum, totalItems: 3, processedItems: 1,
             items: new List<ScrapeRunItem>
             {
@@ -145,7 +145,7 @@ public class RunProgressServiceTests
     [Fact]
     public async Task GetRunProgressAsync_ReturnsMappedDto_WhenRunExists()
     {
-        var forum = new Forum { ForumId = 2, Name = "Forum2", BaseUrl = "https://f2.com", Username = "u2", CredentialKey = "K2" };
+        var forum = new Forum { ForumId = 2, Name = "Forum2", BaseUrl = "https://f2.com", Username = "u2", CredentialKey = "FORUM_K2" };
         var run = CreateRun(5, 2, ScrapeRunStatus.Running, forum, totalItems: 4, processedItems: 2,
             items: new List<ScrapeRunItem>());
 
@@ -190,7 +190,7 @@ public class RunProgressServiceTests
     [Fact]
     public async Task GetRunProgressAsync_UsesItemRepository_NotRunItems()
     {
-        var forum = new Forum { ForumId = 1, Name = "F", BaseUrl = "https://x.com", Username = "u", CredentialKey = "K" };
+        var forum = new Forum { ForumId = 1, Name = "F", BaseUrl = "https://x.com", Username = "u", CredentialKey = "FORUM_K" };
         var run = CreateRun(3, 1, ScrapeRunStatus.Running, forum, totalItems: 1, processedItems: 0,
             items: new List<ScrapeRunItem>
             {
@@ -219,7 +219,7 @@ public class RunProgressServiceTests
     [Fact]
     public async Task GetRunProgressAsync_NoCurrentItem_WhenNoneProcessing()
     {
-        var forum = new Forum { ForumId = 1, Name = "F", BaseUrl = "https://x.com", Username = "u", CredentialKey = "K" };
+        var forum = new Forum { ForumId = 1, Name = "F", BaseUrl = "https://x.com", Username = "u", CredentialKey = "FORUM_K" };
         var run = CreateRun(7, 1, ScrapeRunStatus.Running, forum, totalItems: 2, processedItems: 2,
             items: new List<ScrapeRunItem>());
 
@@ -241,7 +241,7 @@ public class RunProgressServiceTests
     public async Task GetRunProgressAsync_CompletedRun_MapsCorrectly()
     {
         var completedAt = DateTime.UtcNow;
-        var forum = new Forum { ForumId = 1, Name = "F", BaseUrl = "https://x.com", Username = "u", CredentialKey = "K" };
+        var forum = new Forum { ForumId = 1, Name = "F", BaseUrl = "https://x.com", Username = "u", CredentialKey = "FORUM_K" };
         var run = CreateRun(8, 1, ScrapeRunStatus.Complete, forum, totalItems: 1, processedItems: 1,
             items: new List<ScrapeRunItem>());
         run.CompletedAt = completedAt;
@@ -265,7 +265,7 @@ public class RunProgressServiceTests
     public async Task GetRunProgressAsync_MapsStartedAt()
     {
         var startedAt = new DateTime(2026, 4, 1, 12, 0, 0, DateTimeKind.Utc);
-        var forum = new Forum { ForumId = 1, Name = "F", BaseUrl = "https://x.com", Username = "u", CredentialKey = "K" };
+        var forum = new Forum { ForumId = 1, Name = "F", BaseUrl = "https://x.com", Username = "u", CredentialKey = "FORUM_K" };
         var run = CreateRun(9, 1, ScrapeRunStatus.Pending, forum, totalItems: 0, processedItems: 0,
             items: new List<ScrapeRunItem>());
         run.StartedAt = startedAt;
@@ -281,7 +281,7 @@ public class RunProgressServiceTests
     [Fact]
     public async Task GetRunProgressAsync_EmptyItems_ReturnsZeroCounts()
     {
-        var forum = new Forum { ForumId = 1, Name = "F", BaseUrl = "https://x.com", Username = "u", CredentialKey = "K" };
+        var forum = new Forum { ForumId = 1, Name = "F", BaseUrl = "https://x.com", Username = "u", CredentialKey = "FORUM_K" };
         var run = CreateRun(10, 1, ScrapeRunStatus.Pending, forum, totalItems: 0, processedItems: 0,
             items: new List<ScrapeRunItem>());
 
@@ -301,7 +301,7 @@ public class RunProgressServiceTests
     public async Task GetActiveRunsAsync_MapsItemProcessedAt()
     {
         var processedAt = new DateTime(2026, 4, 1, 14, 30, 0, DateTimeKind.Utc);
-        var forum = new Forum { ForumId = 1, Name = "F", BaseUrl = "https://x.com", Username = "u", CredentialKey = "K" };
+        var forum = new Forum { ForumId = 1, Name = "F", BaseUrl = "https://x.com", Username = "u", CredentialKey = "FORUM_K" };
         var run = CreateRun(11, 1, ScrapeRunStatus.Running, forum, totalItems: 1, processedItems: 1,
             items: new List<ScrapeRunItem>
             {
@@ -320,7 +320,7 @@ public class RunProgressServiceTests
     [Fact]
     public async Task GetActiveRunsAsync_MapsCompletedAt()
     {
-        var forum = new Forum { ForumId = 1, Name = "F", BaseUrl = "https://x.com", Username = "u", CredentialKey = "K" };
+        var forum = new Forum { ForumId = 1, Name = "F", BaseUrl = "https://x.com", Username = "u", CredentialKey = "FORUM_K" };
         var run = CreateRun(12, 1, ScrapeRunStatus.Running, forum, totalItems: 0, processedItems: 0,
             items: new List<ScrapeRunItem>());
         run.CompletedAt = null;
@@ -336,7 +336,7 @@ public class RunProgressServiceTests
     [Fact]
     public async Task GetActiveRunsAsync_MapsForumId()
     {
-        var forum = new Forum { ForumId = 7, Name = "F7", BaseUrl = "https://x.com", Username = "u", CredentialKey = "K" };
+        var forum = new Forum { ForumId = 7, Name = "F7", BaseUrl = "https://x.com", Username = "u", CredentialKey = "FORUM_K" };
         var run = CreateRun(13, 7, ScrapeRunStatus.Pending, forum, totalItems: 0, processedItems: 0,
             items: new List<ScrapeRunItem>());
 

--- a/tests/SeriesScraper.Application.Tests/Services/ScrapeOrchestratorTests.cs
+++ b/tests/SeriesScraper.Application.Tests/Services/ScrapeOrchestratorTests.cs
@@ -466,7 +466,7 @@ public class ScrapeOrchestratorTests
             Name = "SlowForum",
             BaseUrl = "https://slow.example.com",
             Username = "user",
-            CredentialKey = "PASS",
+            CredentialKey = "FORUM_PASS",
             PolitenessDelayMs = 100
         };
 

--- a/tests/SeriesScraper.Domain.Tests/Entities/ForumTests.cs
+++ b/tests/SeriesScraper.Domain.Tests/Entities/ForumTests.cs
@@ -1,0 +1,111 @@
+using FluentAssertions;
+using SeriesScraper.Domain.Entities;
+
+namespace SeriesScraper.Domain.Tests.Entities;
+
+public class ForumTests
+{
+    [Theory]
+    [InlineData("FORUM_PASSWORD")]
+    [InlineData("FORUM_WARFORUM_PASSWORD")]
+    [InlineData("FORUM_A1B2C3")]
+    public void CredentialKey_ValidPattern_SetsValue(string key)
+    {
+        var forum = new Forum
+        {
+            Name = "Test",
+            BaseUrl = "https://example.com",
+            Username = "user",
+            CredentialKey = key
+        };
+
+        forum.CredentialKey.Should().Be(key);
+    }
+
+    [Theory]
+    [InlineData("DB_PASSWORD")]
+    [InlineData("GITHUB_TOKEN")]
+    [InlineData("PATH")]
+    [InlineData("HOME")]
+    [InlineData("SECRET_KEY")]
+    [InlineData("forum_password")]
+    [InlineData("FORUM_")]
+    [InlineData("")]
+    public void CredentialKey_InvalidPattern_ThrowsArgumentException(string key)
+    {
+        var act = () => new Forum
+        {
+            Name = "Test",
+            BaseUrl = "https://example.com",
+            Username = "user",
+            CredentialKey = key
+        };
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void CredentialKey_Null_ThrowsArgumentException()
+    {
+        var act = () => new Forum
+        {
+            Name = "Test",
+            BaseUrl = "https://example.com",
+            Username = "user",
+            CredentialKey = null!
+        };
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void CredentialKey_UpdateToInvalid_ThrowsArgumentException()
+    {
+        var forum = new Forum
+        {
+            Name = "Test",
+            BaseUrl = "https://example.com",
+            Username = "user",
+            CredentialKey = "FORUM_VALID_KEY"
+        };
+
+        var act = () => forum.CredentialKey = "DB_PASSWORD";
+
+        act.Should().Throw<ArgumentException>();
+        forum.CredentialKey.Should().Be("FORUM_VALID_KEY");
+    }
+
+    [Fact]
+    public void CredentialKey_UpdateToValid_Succeeds()
+    {
+        var forum = new Forum
+        {
+            Name = "Test",
+            BaseUrl = "https://example.com",
+            Username = "user",
+            CredentialKey = "FORUM_OLD_KEY"
+        };
+
+        forum.CredentialKey = "FORUM_NEW_KEY";
+
+        forum.CredentialKey.Should().Be("FORUM_NEW_KEY");
+    }
+
+    [Fact]
+    public void DefaultValues_AreCorrect()
+    {
+        var forum = new Forum
+        {
+            Name = "Test",
+            BaseUrl = "https://example.com",
+            Username = "user",
+            CredentialKey = "FORUM_PASSWORD"
+        };
+
+        forum.CrawlDepth.Should().Be(1);
+        forum.PolitenessDelayMs.Should().Be(500);
+        forum.IsActive.Should().BeTrue();
+        forum.Sections.Should().BeEmpty();
+        forum.ScrapeRuns.Should().BeEmpty();
+    }
+}

--- a/tests/SeriesScraper.Infrastructure.Tests/BackgroundServices/ForumStructureRefreshServiceTests.cs
+++ b/tests/SeriesScraper.Infrastructure.Tests/BackgroundServices/ForumStructureRefreshServiceTests.cs
@@ -22,7 +22,7 @@ public class ForumStructureRefreshServiceTests
         Name = name,
         BaseUrl = $"https://forum{id}.example.com",
         Username = "user",
-        CredentialKey = "TEST_PASS",
+        CredentialKey = "FORUM_TEST_PASS",
         IsActive = true,
         CrawlDepth = 1
     };

--- a/tests/SeriesScraper.Infrastructure.Tests/Data/LinkRepositoryTests.cs
+++ b/tests/SeriesScraper.Infrastructure.Tests/Data/LinkRepositoryTests.cs
@@ -26,7 +26,7 @@ public class LinkRepositoryTests
             Name = "Test Forum",
             BaseUrl = "https://forum.example.com",
             Username = "testuser",
-            CredentialKey = "TEST_FORUM_PASSWORD"
+            CredentialKey = "FORUM_TEST_PASSWORD"
         };
         context.Forums.Add(forum);
         await context.SaveChangesAsync();

--- a/tests/SeriesScraper.Infrastructure.Tests/Repositories/DatabaseStatsProviderTests.cs
+++ b/tests/SeriesScraper.Infrastructure.Tests/Repositories/DatabaseStatsProviderTests.cs
@@ -99,7 +99,7 @@ public class DatabaseStatsProviderTests : IAsyncLifetime
                 Name = "StatsTestForum",
                 BaseUrl = "https://stats.example.com",
                 Username = "user",
-                CredentialKey = "KEY",
+                CredentialKey = "FORUM_KEY",
                 IsActive = true,
                 CreatedAt = DateTime.UtcNow,
                 UpdatedAt = DateTime.UtcNow

--- a/tests/SeriesScraper.Infrastructure.Tests/Repositories/ForumRepositoryTests.cs
+++ b/tests/SeriesScraper.Infrastructure.Tests/Repositories/ForumRepositoryTests.cs
@@ -40,7 +40,7 @@ public class ForumRepositoryTests : IAsyncLifetime
         Name = name,
         BaseUrl = $"https://{name.ToLowerInvariant().Replace(" ", "")}.example.com",
         Username = "testuser",
-        CredentialKey = "TEST_CREDENTIAL",
+        CredentialKey = "FORUM_TEST_CREDENTIAL",
         IsActive = isActive,
         CreatedAt = DateTime.UtcNow,
         UpdatedAt = DateTime.UtcNow

--- a/tests/SeriesScraper.Infrastructure.Tests/Repositories/ResultsQueryRepositoryTests.cs
+++ b/tests/SeriesScraper.Infrastructure.Tests/Repositories/ResultsQueryRepositoryTests.cs
@@ -74,7 +74,7 @@ public class ResultsQueryRepositoryTests : IAsyncLifetime
             Name = "Test Forum",
             BaseUrl = "https://forum.example.com",
             Username = "testuser",
-            CredentialKey = "TEST_CREDENTIAL",
+            CredentialKey = "FORUM_TEST_CREDENTIAL",
             CreatedAt = DateTime.UtcNow,
             UpdatedAt = DateTime.UtcNow
         };

--- a/tests/SeriesScraper.Infrastructure.Tests/Repositories/ScrapeRunHistoryRepositoryTests.cs
+++ b/tests/SeriesScraper.Infrastructure.Tests/Repositories/ScrapeRunHistoryRepositoryTests.cs
@@ -47,7 +47,7 @@ public class ScrapeRunHistoryRepositoryTests : IAsyncLifetime
             Name = name,
             BaseUrl = $"https://{name.ToLowerInvariant()}.example.com",
             Username = "testuser",
-            CredentialKey = "TEST_KEY",
+            CredentialKey = "FORUM_TEST_KEY",
             IsActive = true,
             CreatedAt = DateTime.UtcNow,
             UpdatedAt = DateTime.UtcNow

--- a/tests/SeriesScraper.Infrastructure.Tests/Repositories/ScrapeRunItemRepositoryTests.cs
+++ b/tests/SeriesScraper.Infrastructure.Tests/Repositories/ScrapeRunItemRepositoryTests.cs
@@ -45,7 +45,7 @@ public class ScrapeRunItemRepositoryTests : IAsyncLifetime
             Name = "TestForum",
             BaseUrl = "https://testforum.example.com",
             Username = "testuser",
-            CredentialKey = "TEST_KEY",
+            CredentialKey = "FORUM_TEST_KEY",
             IsActive = true,
             CreatedAt = DateTime.UtcNow,
             UpdatedAt = DateTime.UtcNow

--- a/tests/SeriesScraper.Infrastructure.Tests/Repositories/WatchlistRepositoryTests.cs
+++ b/tests/SeriesScraper.Infrastructure.Tests/Repositories/WatchlistRepositoryTests.cs
@@ -351,7 +351,7 @@ public class WatchlistRepositoryTests : IAsyncLifetime
                 Name = "Test Forum",
                 BaseUrl = "https://forum.example.com",
                 Username = "testuser",
-                CredentialKey = "TEST_CREDENTIAL",
+                CredentialKey = "FORUM_TEST_CREDENTIAL",
                 CreatedAt = DateTime.UtcNow,
                 UpdatedAt = DateTime.UtcNow
             };
@@ -435,7 +435,7 @@ public class WatchlistRepositoryTests : IAsyncLifetime
                 Name = "Test Forum",
                 BaseUrl = "https://forum.example.com",
                 Username = "testuser",
-                CredentialKey = "TEST_CREDENTIAL",
+                CredentialKey = "FORUM_TEST_CREDENTIAL",
                 CreatedAt = DateTime.UtcNow,
                 UpdatedAt = DateTime.UtcNow
             };
@@ -493,7 +493,7 @@ public class WatchlistRepositoryTests : IAsyncLifetime
                 Name = "Test Forum",
                 BaseUrl = "https://forum.example.com",
                 Username = "testuser",
-                CredentialKey = "TEST_CREDENTIAL",
+                CredentialKey = "FORUM_TEST_CREDENTIAL",
                 CreatedAt = DateTime.UtcNow,
                 UpdatedAt = DateTime.UtcNow
             };


### PR DESCRIPTION
Closes #51

## Security Fix

Prevents arbitrary environment variable reads via the Forums.credential_key column by enforcing the FORUM_* prefix validation at all entry points.

### Changes

1. **Forum entity (Domain layer)** — Added backing field with validation in the CredentialKey setter. Any code setting this property now goes through CredentialKey value object validation, rejecting keys like `DB_PASSWORD`, `GITHUB_TOKEN`, `PATH`, etc.

2. **ForumCredentialService.ValidateActiveForumCredentials** — Added CredentialKey validation before reading environment variables. Previously this method read arbitrary env var names without format checks.

3. **ForumTests** — New domain entity test class verifying:
   - Valid FORUM_* keys are accepted
   - Invalid keys (DB_PASSWORD, GITHUB_TOKEN, etc.) are rejected
   - Null/empty keys are rejected
   - Update-to-invalid is blocked

4. **ForumCredentialServiceTests** — Added attack scenario tests:
   - ResolveCredential blocks arbitrary env var names
   - ValidateActiveForumCredentials blocks arbitrary env var names
   - Inactive forums with invalid keys are safely skipped

5. **Test fixtures updated** — 12 test files updated to use valid `FORUM_*` prefixed credential keys, ensuring they work with the new domain validation.

### What was already in place
- CredentialKey value object with regex validation
- ForumCredentialService.ResolveCredential validated via value object
- Comprehensive unit tests for CredentialKey and ResolveCredential

## Test plan
- [x] Build succeeds (0 errors)
- [x] All 1281 tests pass
- [x] CredentialKey rejects invalid env var names at entity level
- [x] Attack scenario from issue description is blocked at all entry points