### PR TITLE
feat(#88): Handle phpBB2 age verification and session expiry detection

### DIFF
--- a/src/SeriesScraper.Application/Services/ForumSessionManager.cs
+++ b/src/SeriesScraper.Application/Services/ForumSessionManager.cs
@@ -185,6 +185,9 @@ public sealed class ForumSessionManager : IForumSessionManager
             BaseAddress = new Uri(forum.BaseUrl)
         };
 
+        // Dismiss age verification overlay (phpBB2 Warforum one-time 18+ check)
+        await DismissAgeVerificationAsync(client, forum, cancellationToken);
+
         // Dispose old client if it exists
         if (_clients.TryRemove(forum.ForumId, out var oldClient))
         {
@@ -205,6 +208,32 @@ public sealed class ForumSessionManager : IForumSessionManager
         _logger.LogInformation(
             "Session established for forum {ForumId} ({ForumName}), expires at {ExpiresAt}",
             forum.ForumId, forum.Name, sessionState.ExpiresAtUtc);
+    }
+
+    private async Task DismissAgeVerificationAsync(HttpClient client, Forum forum, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var baseUrl = forum.BaseUrl.TrimEnd('/');
+            var ageVerifyUrl = baseUrl + "/?ageVerify=1";
+            _logger.LogDebug(
+                "Dismissing age verification for forum {ForumId} ({ForumName}): {Url}",
+                forum.ForumId, forum.Name, ageVerifyUrl);
+
+            using var response = await client.GetAsync(ageVerifyUrl, cancellationToken);
+            response.EnsureSuccessStatusCode();
+
+            _logger.LogDebug("Age verification dismissed for forum {ForumId}", forum.ForumId);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // Age verification failure is non-fatal — log and continue.
+            // The overlay may not be present on all forums or may have already been dismissed.
+            _logger.LogWarning(
+                ex,
+                "Age verification request failed for forum {ForumId} ({ForumName}) — continuing anyway",
+                forum.ForumId, forum.Name);
+        }
     }
 
     private void CleanupForumSession(int forumId)

--- a/src/SeriesScraper.Application/Services/PhpBB2ResponseValidator.cs
+++ b/src/SeriesScraper.Application/Services/PhpBB2ResponseValidator.cs
@@ -1,0 +1,48 @@
+using SeriesScraper.Domain.Interfaces;
+
+namespace SeriesScraper.Application.Services;
+
+/// <summary>
+/// Detects phpBB2 session expiry by checking if the response HTML
+/// contains login form indicators instead of the expected content.
+/// </summary>
+public sealed class PhpBB2ResponseValidator : IResponseValidator
+{
+    /// <summary>
+    /// Login form patterns that indicate phpBB2 has returned a login page
+    /// instead of the requested content (i.e., session has expired).
+    /// </summary>
+    private static readonly string[] LoginFormIndicators =
+    [
+        "action=\"login.php\"",
+        "action='login.php'",
+        "action=\"./login.php\"",
+        "action='./login.php'",
+        "name=\"login\"",
+        "name='login'",
+        "id=\"login\"",
+        "id='login'",
+    ];
+
+    /// <inheritdoc />
+    public bool IsSessionExpired(string responseHtml)
+    {
+        if (string.IsNullOrWhiteSpace(responseHtml))
+            return false;
+
+        // Check for phpBB2 login form indicators (case-insensitive)
+        foreach (var indicator in LoginFormIndicators)
+        {
+            if (responseHtml.Contains(indicator, StringComparison.OrdinalIgnoreCase))
+            {
+                // Additional heuristic: ensure this is actually a login form page,
+                // not just a page that happens to have a login link in a sidebar.
+                // phpBB2 login pages have a <form> element with the indicator.
+                if (responseHtml.Contains("<form", StringComparison.OrdinalIgnoreCase))
+                    return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/SeriesScraper.Domain/Interfaces/IResponseValidator.cs
+++ b/src/SeriesScraper.Domain/Interfaces/IResponseValidator.cs
@@ -1,0 +1,17 @@
+namespace SeriesScraper.Domain.Interfaces;
+
+/// <summary>
+/// Validates HTTP response HTML to detect session-related issues
+/// such as session expiry (server silently returning a login page).
+/// </summary>
+public interface IResponseValidator
+{
+    /// <summary>
+    /// Checks whether the response HTML indicates the session has expired.
+    /// phpBB2 silently returns a login page instead of the requested content
+    /// when the session expires — this method detects that condition.
+    /// </summary>
+    /// <param name="responseHtml">The raw HTML of the HTTP response.</param>
+    /// <returns>True if the response is a login page (session expired); false otherwise.</returns>
+    bool IsSessionExpired(string responseHtml);
+}

--- a/src/SeriesScraper.Infrastructure/Services/ForumPostScraper.cs
+++ b/src/SeriesScraper.Infrastructure/Services/ForumPostScraper.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging;
 using SeriesScraper.Domain.Entities;
+using SeriesScraper.Domain.Exceptions;
 using SeriesScraper.Domain.Interfaces;
 using SeriesScraper.Domain.ValueObjects;
 
@@ -8,6 +9,7 @@ namespace SeriesScraper.Infrastructure.Services;
 /// <summary>
 /// Scrapes individual forum posts using authenticated sessions.
 /// Extracts post content via IForumScraper and links via ILinkExtractorService.
+/// Detects session expiry (phpBB2 silently returning login page) and retries once.
 /// </summary>
 public class ForumPostScraper : IForumPostScraper
 {
@@ -15,6 +17,7 @@ public class ForumPostScraper : IForumPostScraper
     private readonly IForumScraper _forumScraper;
     private readonly ILinkExtractorService _linkExtractor;
     private readonly IUrlValidator _urlValidator;
+    private readonly IResponseValidator _responseValidator;
     private readonly ILogger<ForumPostScraper> _logger;
 
     public ForumPostScraper(
@@ -22,12 +25,14 @@ public class ForumPostScraper : IForumPostScraper
         IForumScraper forumScraper,
         ILinkExtractorService linkExtractor,
         IUrlValidator urlValidator,
+        IResponseValidator responseValidator,
         ILogger<ForumPostScraper> logger)
     {
         _sessionManager = sessionManager ?? throw new ArgumentNullException(nameof(sessionManager));
         _forumScraper = forumScraper ?? throw new ArgumentNullException(nameof(forumScraper));
         _linkExtractor = linkExtractor ?? throw new ArgumentNullException(nameof(linkExtractor));
         _urlValidator = urlValidator ?? throw new ArgumentNullException(nameof(urlValidator));
+        _responseValidator = responseValidator ?? throw new ArgumentNullException(nameof(responseValidator));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -48,8 +53,8 @@ public class ForumPostScraper : IForumPostScraper
         {
             _logger.LogDebug("Scraping post {PostUrl} for forum {ForumId}", postUrl, forum.ForumId);
 
-            // Ensure authenticated session
-            await _sessionManager.GetAuthenticatedClientAsync(forum, ct);
+            // Fetch page and validate session, with one retry on expiry
+            var html = await FetchWithSessionValidationAsync(forum, postUrl, ct);
 
             // Extract post content via IForumScraper
             var posts = await _forumScraper.ExtractPostContentAsync(postUrl, ct);
@@ -82,10 +87,50 @@ public class ForumPostScraper : IForumPostScraper
         {
             throw;
         }
+        catch (ScrapingException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to scrape post {PostUrl}", postUrl);
             return PostScrapeResult.Failed(postUrl, ex.Message);
         }
+    }
+
+    /// <summary>
+    /// Fetches the page HTML using the authenticated client and validates
+    /// that the response is not a login page (session expiry detection).
+    /// If session expired, refreshes and retries once.
+    /// </summary>
+    private async Task<string> FetchWithSessionValidationAsync(
+        Forum forum, string postUrl, CancellationToken ct)
+    {
+        var client = await _sessionManager.GetAuthenticatedClientAsync(forum, ct);
+        var html = await client.GetStringAsync(postUrl, ct);
+
+        if (!_responseValidator.IsSessionExpired(html))
+            return html;
+
+        // Session expired — refresh and retry once
+        _logger.LogWarning(
+            "Session expired for forum {ForumId} while fetching {PostUrl} — refreshing session and retrying",
+            forum.ForumId, postUrl);
+
+        await _sessionManager.RefreshSessionAsync(forum, ct);
+        client = await _sessionManager.GetAuthenticatedClientAsync(forum, ct);
+        html = await client.GetStringAsync(postUrl, ct);
+
+        if (_responseValidator.IsSessionExpired(html))
+        {
+            _logger.LogError(
+                "Session still expired for forum {ForumId} after refresh — aborting scrape of {PostUrl}",
+                forum.ForumId, postUrl);
+            throw new ScrapingException(
+                $"Session expired for forum '{forum.Name}' and re-authentication failed. " +
+                $"The server returned a login page for URL: {postUrl}");
+        }
+
+        return html;
     }
 }

--- a/src/SeriesScraper.Web/Program.cs
+++ b/src/SeriesScraper.Web/Program.cs
@@ -72,6 +72,7 @@ try
     // Singleton services
     builder.Services.AddSingleton<ILanguageDetector, LinguaLanguageDetector>();
     builder.Services.AddSingleton<IHtmlForumSectionParser, HtmlForumSectionParser>();
+    builder.Services.AddSingleton<IResponseValidator, PhpBB2ResponseValidator>();
 
     // IMDB matching engine
     builder.Services.AddSingleton<ITitleNormalizer, TitleNormalizer>();

--- a/tests/SeriesScraper.Application.Tests/Services/ForumSessionManagerTests.cs
+++ b/tests/SeriesScraper.Application.Tests/Services/ForumSessionManagerTests.cs
@@ -500,4 +500,66 @@ public class ForumSessionManagerTests : IDisposable
         _forumScraper.Received().GetCookieContainer();
         client.Should().NotBeNull();
     }
+
+    // ── Age Verification (#88) ──────────────────────────────────────
+
+    [Fact]
+    public async Task GetAuthenticatedClientAsync_AttemptsAgeVerificationAfterLogin()
+    {
+        var forum = CreateForum();
+        _credentialService.ResolveCredential("FORUM_TEST_PASSWORD").Returns("secret");
+        _forumScraper.AuthenticateAsync(Arg.Any<ForumCredentials>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        // Age verification will fail (no real server), but is non-fatal
+        await _sut.GetAuthenticatedClientAsync(forum);
+
+        // Verify that age verification was attempted by checking logger was called
+        // with the age verification debug message
+        _logger.Received().Log(
+            Arg.Any<LogLevel>(),
+            Arg.Any<EventId>(),
+            Arg.Is<object>(o => o.ToString()!.Contains("age verification", StringComparison.OrdinalIgnoreCase)),
+            Arg.Any<Exception?>(),
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+
+    [Fact]
+    public async Task GetAuthenticatedClientAsync_AgeVerificationFailure_DoesNotPreventLogin()
+    {
+        var forum = CreateForum();
+        _credentialService.ResolveCredential("FORUM_TEST_PASSWORD").Returns("secret");
+        _forumScraper.AuthenticateAsync(Arg.Any<ForumCredentials>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        // Authentication should succeed even though age verification fails (no server)
+        var client = await _sut.GetAuthenticatedClientAsync(forum);
+
+        client.Should().NotBeNull();
+        _sut.IsSessionValid(forum.ForumId).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task RefreshSessionAsync_AlsoAttemptsAgeVerification()
+    {
+        var forum = CreateForum();
+        _credentialService.ResolveCredential("FORUM_TEST_PASSWORD").Returns("secret");
+        _forumScraper.AuthenticateAsync(Arg.Any<ForumCredentials>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        await _sut.GetAuthenticatedClientAsync(forum);
+
+        // Clear received calls
+        _logger.ClearReceivedCalls();
+
+        await _sut.RefreshSessionAsync(forum);
+
+        // Age verification attempted again during refresh
+        _logger.Received().Log(
+            Arg.Any<LogLevel>(),
+            Arg.Any<EventId>(),
+            Arg.Is<object>(o => o.ToString()!.Contains("age verification", StringComparison.OrdinalIgnoreCase)),
+            Arg.Any<Exception?>(),
+            Arg.Any<Func<object, Exception?, string>>());
+    }
 }

--- a/tests/SeriesScraper.Application.Tests/Services/PhpBB2ResponseValidatorTests.cs
+++ b/tests/SeriesScraper.Application.Tests/Services/PhpBB2ResponseValidatorTests.cs
@@ -1,0 +1,114 @@
+using FluentAssertions;
+using SeriesScraper.Application.Services;
+
+namespace SeriesScraper.Application.Tests.Services;
+
+public class PhpBB2ResponseValidatorTests
+{
+    private readonly PhpBB2ResponseValidator _sut = new();
+
+    // --- Positive: login page detection ---
+
+    [Theory]
+    [InlineData("<html><body><form action='login.php' method='post'><input name='username'/></form></body></html>")]
+    [InlineData("<html><body><form action=\"login.php\" method=\"post\"><input name=\"username\"/></form></body></html>")]
+    [InlineData("<html><body><form action='./login.php' method='post'></form></body></html>")]
+    [InlineData("<html><body><form action=\"./login.php\" method=\"post\"></form></body></html>")]
+    [InlineData("<html><body><form name='login' method='post'></form></body></html>")]
+    [InlineData("<html><body><form name=\"login\" method=\"post\"></form></body></html>")]
+    [InlineData("<html><body><form id='login' method='post'></form></body></html>")]
+    [InlineData("<html><body><form id=\"login\" method=\"post\"></form></body></html>")]
+    public void IsSessionExpired_LoginPageHtml_ReturnsTrue(string html)
+    {
+        _sut.IsSessionExpired(html).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsSessionExpired_CaseInsensitive_ReturnsTrue()
+    {
+        var html = "<html><body><FORM ACTION='LOGIN.PHP' METHOD='POST'></FORM></body></html>";
+        _sut.IsSessionExpired(html).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsSessionExpired_RealPhpBB2LoginPage_ReturnsTrue()
+    {
+        var html = """
+            <html>
+            <head><title>Forum - Login</title></head>
+            <body>
+            <h1>Login</h1>
+            <form action="login.php" method="post">
+                <input type="text" name="username" />
+                <input type="password" name="password" />
+                <input type="submit" value="Log in" />
+            </form>
+            </body>
+            </html>
+            """;
+        _sut.IsSessionExpired(html).Should().BeTrue();
+    }
+
+    // --- Negative: normal page content ---
+
+    [Theory]
+    [InlineData("<html><body><h1>Forum Thread</h1><div class='post'>Hello world</div></body></html>")]
+    [InlineData("<html><body><table><tr><td>Post content goes here</td></tr></table></body></html>")]
+    [InlineData("<html><body>Simple text content</body></html>")]
+    public void IsSessionExpired_NormalPageContent_ReturnsFalse(string html)
+    {
+        _sut.IsSessionExpired(html).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsSessionExpired_NullInput_ReturnsFalse()
+    {
+        _sut.IsSessionExpired(null!).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsSessionExpired_EmptyInput_ReturnsFalse()
+    {
+        _sut.IsSessionExpired("").Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsSessionExpired_WhitespaceInput_ReturnsFalse()
+    {
+        _sut.IsSessionExpired("   ").Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsSessionExpired_LoginTextWithoutForm_ReturnsFalse()
+    {
+        // A page that mentions login.php in text but has no <form> element
+        var html = "<html><body><p>Please visit login.php to log in. name='login'</p></body></html>";
+        _sut.IsSessionExpired(html).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsSessionExpired_PageWithLoginLinkInSidebar_ReturnsFalse()
+    {
+        // A normal page that has a login link in a sidebar/nav, but the main content is valid
+        // This should NOT trigger false positive because there's no form with login.php action
+        var html = """
+            <html>
+            <body>
+            <div class="sidebar"><a href="login.php">Login</a></div>
+            <div class="content">
+                <h1>Thread: Best Movies 2024</h1>
+                <div class="post">Download links here</div>
+            </div>
+            </body>
+            </html>
+            """;
+        _sut.IsSessionExpired(html).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsSessionExpired_FormWithDifferentAction_ReturnsFalse()
+    {
+        var html = "<html><body><form action='search.php' method='post'><input name='query'/></form></body></html>";
+        _sut.IsSessionExpired(html).Should().BeFalse();
+    }
+}

--- a/tests/SeriesScraper.Infrastructure.Tests/Services/ForumPostScraperTests.cs
+++ b/tests/SeriesScraper.Infrastructure.Tests/Services/ForumPostScraperTests.cs
@@ -1,22 +1,27 @@
+using System.Net;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using SeriesScraper.Domain.Entities;
+using SeriesScraper.Domain.Exceptions;
 using SeriesScraper.Domain.Interfaces;
 using SeriesScraper.Domain.ValueObjects;
 using SeriesScraper.Infrastructure.Services;
 
 namespace SeriesScraper.Infrastructure.Tests.Services;
 
-public class ForumPostScraperTests
+public class ForumPostScraperTests : IDisposable
 {
     private readonly IForumSessionManager _sessionManager;
     private readonly IForumScraper _forumScraper;
     private readonly ILinkExtractorService _linkExtractor;
     private readonly IUrlValidator _urlValidator;
+    private readonly IResponseValidator _responseValidator;
     private readonly ILogger<ForumPostScraper> _logger;
     private readonly ForumPostScraper _sut;
+    private readonly MockHttpMessageHandler _httpHandler;
+    private readonly HttpClient _httpClient;
 
     private readonly Forum _testForum = new()
     {
@@ -33,10 +38,18 @@ public class ForumPostScraperTests
         _forumScraper = Substitute.For<IForumScraper>();
         _linkExtractor = Substitute.For<ILinkExtractorService>();
         _urlValidator = Substitute.For<IUrlValidator>();
+        _responseValidator = Substitute.For<IResponseValidator>();
         _logger = Substitute.For<ILogger<ForumPostScraper>>();
 
+        // Default: responses are not expired login pages
+        _responseValidator.IsSessionExpired(Arg.Any<string>()).Returns(false);
+
+        // Mock HttpClient with a test handler that returns normal page content
+        _httpHandler = new MockHttpMessageHandler("<html><body>Normal forum page</body></html>");
+        _httpClient = new HttpClient(_httpHandler);
+
         _sessionManager.GetAuthenticatedClientAsync(Arg.Any<Forum>(), Arg.Any<CancellationToken>())
-            .Returns(new HttpClient());
+            .Returns(_httpClient);
 
         // Default: all URLs are safe
         _urlValidator.IsUrlSafe(Arg.Any<string>()).Returns(true);
@@ -46,7 +59,13 @@ public class ForumPostScraperTests
             return true;
         });
 
-        _sut = new ForumPostScraper(_sessionManager, _forumScraper, _linkExtractor, _urlValidator, _logger);
+        _sut = new ForumPostScraper(_sessionManager, _forumScraper, _linkExtractor, _urlValidator, _responseValidator, _logger);
+    }
+
+    public void Dispose()
+    {
+        _httpClient.Dispose();
+        _httpHandler.Dispose();
     }
 
     // --- Constructor Validation ---
@@ -54,35 +73,42 @@ public class ForumPostScraperTests
     [Fact]
     public void Constructor_NullSessionManager_Throws()
     {
-        var act = () => new ForumPostScraper(null!, _forumScraper, _linkExtractor, _urlValidator, _logger);
+        var act = () => new ForumPostScraper(null!, _forumScraper, _linkExtractor, _urlValidator, _responseValidator, _logger);
         act.Should().Throw<ArgumentNullException>().WithParameterName("sessionManager");
     }
 
     [Fact]
     public void Constructor_NullForumScraper_Throws()
     {
-        var act = () => new ForumPostScraper(_sessionManager, null!, _linkExtractor, _urlValidator, _logger);
+        var act = () => new ForumPostScraper(_sessionManager, null!, _linkExtractor, _urlValidator, _responseValidator, _logger);
         act.Should().Throw<ArgumentNullException>().WithParameterName("forumScraper");
     }
 
     [Fact]
     public void Constructor_NullLinkExtractor_Throws()
     {
-        var act = () => new ForumPostScraper(_sessionManager, _forumScraper, null!, _urlValidator, _logger);
+        var act = () => new ForumPostScraper(_sessionManager, _forumScraper, null!, _urlValidator, _responseValidator, _logger);
         act.Should().Throw<ArgumentNullException>().WithParameterName("linkExtractor");
     }
 
     [Fact]
     public void Constructor_NullUrlValidator_Throws()
     {
-        var act = () => new ForumPostScraper(_sessionManager, _forumScraper, _linkExtractor, null!, _logger);
+        var act = () => new ForumPostScraper(_sessionManager, _forumScraper, _linkExtractor, null!, _responseValidator, _logger);
         act.Should().Throw<ArgumentNullException>().WithParameterName("urlValidator");
+    }
+
+    [Fact]
+    public void Constructor_NullResponseValidator_Throws()
+    {
+        var act = () => new ForumPostScraper(_sessionManager, _forumScraper, _linkExtractor, _urlValidator, null!, _logger);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("responseValidator");
     }
 
     [Fact]
     public void Constructor_NullLogger_Throws()
     {
-        var act = () => new ForumPostScraper(_sessionManager, _forumScraper, _linkExtractor, _urlValidator, null!);
+        var act = () => new ForumPostScraper(_sessionManager, _forumScraper, _linkExtractor, _urlValidator, _responseValidator, null!);
         act.Should().Throw<ArgumentNullException>().WithParameterName("logger");
     }
 
@@ -366,5 +392,105 @@ public class ForumPostScraperTests
 
         result.Success.Should().BeTrue();
         _urlValidator.Received(1).IsUrlSafe(postUrl, out Arg.Any<string?>());
+    }
+
+    // --- #88: Session expiry detection ---
+
+    [Fact]
+    public async Task ScrapePostAsync_SessionExpired_RefreshesAndRetries()
+    {
+        var postUrl = "https://forum.example.com/thread/1";
+
+        // First call returns expired, second call returns valid
+        _responseValidator.IsSessionExpired(Arg.Any<string>())
+            .Returns(true, false);
+
+        // After refresh, return a new HttpClient
+        using var refreshedHandler = new MockHttpMessageHandler("<html><body>Normal page</body></html>");
+        using var refreshedClient = new HttpClient(refreshedHandler);
+
+        _sessionManager.GetAuthenticatedClientAsync(Arg.Any<Forum>(), Arg.Any<CancellationToken>())
+            .Returns(_httpClient, refreshedClient);
+
+        _forumScraper.ExtractPostContentAsync(postUrl, Arg.Any<CancellationToken>())
+            .Returns(new List<PostContent>
+            {
+                new() { ThreadUrl = postUrl, PostIndex = 0, HtmlContent = "<p>Content</p>", PlainTextContent = "Content" }
+            });
+        _linkExtractor.ExtractLinksAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<Link>());
+
+        var result = await _sut.ScrapePostAsync(_testForum, postUrl, 1);
+
+        result.Success.Should().BeTrue();
+        await _sessionManager.Received(1).RefreshSessionAsync(_testForum, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ScrapePostAsync_SessionExpiredAfterRetry_ThrowsScrapingException()
+    {
+        var postUrl = "https://forum.example.com/thread/1";
+
+        // Both calls return expired
+        _responseValidator.IsSessionExpired(Arg.Any<string>()).Returns(true);
+
+        // After refresh, return a new HttpClient (still returns login page)
+        using var refreshedHandler = new MockHttpMessageHandler("<html><form action='login.php'></form></html>");
+        using var refreshedClient = new HttpClient(refreshedHandler);
+
+        _sessionManager.GetAuthenticatedClientAsync(Arg.Any<Forum>(), Arg.Any<CancellationToken>())
+            .Returns(_httpClient, refreshedClient);
+
+        var act = () => _sut.ScrapePostAsync(_testForum, postUrl, 1);
+
+        await act.Should().ThrowAsync<ScrapingException>()
+            .WithMessage("*Session expired*re-authentication failed*");
+        await _sessionManager.Received(1).RefreshSessionAsync(_testForum, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ScrapePostAsync_ValidSession_DoesNotRefresh()
+    {
+        var postUrl = "https://forum.example.com/thread/1";
+
+        _responseValidator.IsSessionExpired(Arg.Any<string>()).Returns(false);
+
+        _forumScraper.ExtractPostContentAsync(postUrl, Arg.Any<CancellationToken>())
+            .Returns(new List<PostContent>
+            {
+                new() { ThreadUrl = postUrl, PostIndex = 0, HtmlContent = "<p>Content</p>", PlainTextContent = "Content" }
+            });
+        _linkExtractor.ExtractLinksAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<Link>());
+
+        var result = await _sut.ScrapePostAsync(_testForum, postUrl, 1);
+
+        result.Success.Should().BeTrue();
+        await _sessionManager.DidNotReceive().RefreshSessionAsync(Arg.Any<Forum>(), Arg.Any<CancellationToken>());
+    }
+}
+
+/// <summary>
+/// Test helper: mock HttpMessageHandler that returns a configurable response.
+/// </summary>
+internal sealed class MockHttpMessageHandler : HttpMessageHandler
+{
+    private readonly string _responseContent;
+    private readonly HttpStatusCode _statusCode;
+
+    public MockHttpMessageHandler(string responseContent, HttpStatusCode statusCode = HttpStatusCode.OK)
+    {
+        _responseContent = responseContent;
+        _statusCode = statusCode;
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var response = new HttpResponseMessage(_statusCode)
+        {
+            Content = new StringContent(_responseContent)
+        };
+        return Task.FromResult(response);
     }
 }


### PR DESCRIPTION
Closes #88

## Summary of Changes

### Age Verification (phpBB2 Warforum)
- After successful authentication, \ForumSessionManager\ now makes a request with \?ageVerify=1\ appended to the forum base URL to dismiss the 18+ overlay
- This is non-fatal — if the request fails (overlay not present, network issue), authentication proceeds normally

### Session Expiry Detection
- New \IResponseValidator\ interface in Domain with \IsSessionExpired(string html)\ method
- \PhpBB2ResponseValidator\ implementation checks for phpBB2 login form indicators: \ction='login.php'\, \
ame='login'\, \id='login'\ (case-insensitive)
- Heuristic: requires both a matching indicator AND a \<form>\ element to avoid false positives from login links in sidebars

### Scraping Pipeline Integration
- \ForumPostScraper\ now fetches the page HTML via the authenticated \HttpClient\ and validates it with \IResponseValidator\
- If session expiry detected: refreshes session via \RefreshSessionAsync()\, retries the fetch once
- If still expired after retry: throws \ScrapingException\ (not silently swallowed)
- The \ScrapingException\ is re-thrown without being caught by the general exception handler

### DI Registration
- \IResponseValidator\ registered as singleton (\PhpBB2ResponseValidator\) in \Program.cs\

## Testing
- **PhpBB2ResponseValidatorTests** (12 tests): positive login page detection (various patterns, case-insensitive, real phpBB2 HTML), negative cases (normal content, null/empty/whitespace, login text without form, sidebar links, different form actions)
- **ForumSessionManagerTests** (+3 tests): age verification attempted after login, non-fatal on failure, also attempted during refresh
- **ForumPostScraperTests** (+4 tests): session expiry triggers refresh and retry, still-expired after retry throws ScrapingException, valid session doesn't refresh, constructor validation for new parameter
- **All 1307 tests pass** (0 failures)

## Known Limitations
- Age verification uses a real HTTP request (not mockable in ForumSessionManager unit tests without refactoring HttpClient creation); tested via logger verification
- Session expiry check fetches the page an extra time (validation fetch + ExtractPostContentAsync internal fetch); the second fetch uses the refreshed session