### PR TITLE
feat(#100): Add Language field to Link entity and parse language tags from thread titles

### DIFF
--- a/src/SeriesScraper.Application/Services/LanguageTagParser.cs
+++ b/src/SeriesScraper.Application/Services/LanguageTagParser.cs
@@ -1,0 +1,104 @@
+using System.Text.RegularExpressions;
+using SeriesScraper.Domain.Interfaces;
+
+namespace SeriesScraper.Application.Services;
+
+/// <summary>
+/// Parses language tags from forum thread titles.
+/// Expects the pattern: "Title / AlternateTitle / CZ, EN"
+/// where the last slash-separated segment contains comma-separated country-style codes.
+/// Maps country codes to ISO 639-1 language codes.
+/// </summary>
+public class LanguageTagParser : ILanguageTagParser
+{
+    private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(2);
+
+    /// <summary>
+    /// Known country-code to ISO 639-1 mappings.
+    /// </summary>
+    private static readonly Dictionary<string, string> CountryToIso = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["CZ"] = "cs",
+        ["SK"] = "sk",
+        ["EN"] = "en",
+        ["DE"] = "de",
+        ["FR"] = "fr",
+        ["ES"] = "es",
+        ["IT"] = "it",
+        ["PL"] = "pl",
+        ["HU"] = "hu",
+        ["RU"] = "ru",
+        ["PT"] = "pt",
+        ["NL"] = "nl",
+        ["RO"] = "ro",
+        ["HR"] = "hr",
+        ["SR"] = "sr",
+        ["BG"] = "bg",
+        ["UA"] = "uk",
+        ["JP"] = "ja",
+        ["KR"] = "ko",
+        ["CN"] = "zh",
+    };
+
+    // Matches country-style codes: 2-3 uppercase letters
+    private static readonly Regex CountryCodePattern = new(
+        @"^[A-Za-z]{2,3}$",
+        RegexOptions.Compiled,
+        RegexTimeout);
+
+    public IReadOnlyList<string> ParseLanguageTags(string threadTitle)
+    {
+        if (string.IsNullOrWhiteSpace(threadTitle))
+            return Array.Empty<string>();
+
+        // Split by '/' and take the last segment
+        var segments = threadTitle.Split('/');
+        if (segments.Length < 2)
+            return Array.Empty<string>();
+
+        var lastSegment = segments[^1].Trim();
+        if (string.IsNullOrEmpty(lastSegment))
+            return Array.Empty<string>();
+
+        // Split by ',' to get individual codes
+        var codes = lastSegment.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+
+        var result = new List<string>();
+        foreach (var code in codes)
+        {
+            if (!IsValidCountryCode(code))
+                return Array.Empty<string>(); // If any token isn't a code, this isn't a language segment
+
+            var iso = MapToIso(code);
+            if (!result.Contains(iso, StringComparer.Ordinal))
+                result.Add(iso);
+        }
+
+        return result;
+    }
+
+    public string? GetLanguageString(string threadTitle)
+    {
+        var tags = ParseLanguageTags(threadTitle);
+        return tags.Count > 0 ? string.Join(",", tags) : null;
+    }
+
+    private static bool IsValidCountryCode(string code)
+    {
+        try
+        {
+            return CountryCodePattern.IsMatch(code);
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            return false;
+        }
+    }
+
+    private static string MapToIso(string countryCode)
+    {
+        return CountryToIso.TryGetValue(countryCode, out var iso)
+            ? iso
+            : countryCode.ToLowerInvariant();
+    }
+}

--- a/src/SeriesScraper.Application/Services/ResultsService.cs
+++ b/src/SeriesScraper.Application/Services/ResultsService.cs
@@ -78,7 +78,8 @@ public class ResultsService : IResultsService
             LinkTypeName = l.LinkType?.Name ?? "Unknown",
             ParsedSeason = l.ParsedSeason,
             ParsedEpisode = l.ParsedEpisode,
-            IsCurrent = l.IsCurrent
+            IsCurrent = l.IsCurrent,
+            Language = l.Language
         }).ToList();
 
         var detail = new ResultDetailDto

--- a/src/SeriesScraper.Domain/Entities/Link.cs
+++ b/src/SeriesScraper.Domain/Entities/Link.cs
@@ -33,6 +33,13 @@ public class Link
     /// </summary>
     public bool IsCurrent { get; set; } = true;
     
+    /// <summary>
+    /// ISO 639-1 language code(s) parsed from the thread title.
+    /// Comma-separated when multiple languages are present (e.g. "cs,en").
+    /// Null if no language tag was detected.
+    /// </summary>
+    public string? Language { get; set; }
+    
     public int RunId { get; set; }
     
     // Navigation properties

--- a/src/SeriesScraper.Domain/Interfaces/ILanguageTagParser.cs
+++ b/src/SeriesScraper.Domain/Interfaces/ILanguageTagParser.cs
@@ -1,0 +1,21 @@
+namespace SeriesScraper.Domain.Interfaces;
+
+/// <summary>
+/// Parses language tags from forum thread titles.
+/// Thread titles encode language as a slash-separated suffix with comma-separated country codes:
+/// "Tenkrát poprvé / Never Have I Ever / CZ, EN"
+/// </summary>
+public interface ILanguageTagParser
+{
+    /// <summary>
+    /// Extracts ISO 639-1 language codes from a thread title.
+    /// Returns empty list if no language tags are detected.
+    /// </summary>
+    IReadOnlyList<string> ParseLanguageTags(string threadTitle);
+
+    /// <summary>
+    /// Returns a comma-separated string of ISO 639-1 codes from the thread title,
+    /// or null if no language tags are detected.
+    /// </summary>
+    string? GetLanguageString(string threadTitle);
+}

--- a/src/SeriesScraper.Domain/Interfaces/IResultsService.cs
+++ b/src/SeriesScraper.Domain/Interfaces/IResultsService.cs
@@ -61,6 +61,7 @@ public record LinkDto
     public int? ParsedSeason { get; init; }
     public int? ParsedEpisode { get; init; }
     public bool IsCurrent { get; init; }
+    public string? Language { get; init; }
 }
 
 public record ResultFilterDto

--- a/src/SeriesScraper.Infrastructure/Data/Configurations/LinkConfiguration.cs
+++ b/src/SeriesScraper.Infrastructure/Data/Configurations/LinkConfiguration.cs
@@ -30,6 +30,9 @@ public class LinkConfiguration : IEntityTypeConfiguration<Link>
         entity.Property(e => e.IsCurrent)
             .HasDefaultValue(true);
         
+        entity.Property(e => e.Language)
+            .HasMaxLength(50);
+        
         entity.HasOne(e => e.LinkType)
             .WithMany(lt => lt.Links)
             .HasForeignKey(e => e.LinkTypeId)

--- a/src/SeriesScraper.Infrastructure/Data/Migrations/20260403130723_AddLanguageToLink.Designer.cs
+++ b/src/SeriesScraper.Infrastructure/Data/Migrations/20260403130723_AddLanguageToLink.Designer.cs
@@ -2,18 +2,21 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SeriesScraper.Infrastructure.Data;
 
 #nullable disable
 
-namespace SeriesScraper.Infrastructure.Migrations
+namespace SeriesScraper.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260403130723_AddLanguageToLink")]
+    partial class AddLanguageToLink
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SeriesScraper.Infrastructure/Data/Migrations/20260403130723_AddLanguageToLink.cs
+++ b/src/SeriesScraper.Infrastructure/Data/Migrations/20260403130723_AddLanguageToLink.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SeriesScraper.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLanguageToLink : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "language",
+                table: "links",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "language",
+                table: "links");
+        }
+    }
+}

--- a/src/SeriesScraper.Infrastructure/Services/ForumPostScraper.cs
+++ b/src/SeriesScraper.Infrastructure/Services/ForumPostScraper.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 using SeriesScraper.Domain.Entities;
 using SeriesScraper.Domain.Exceptions;
@@ -13,9 +14,16 @@ namespace SeriesScraper.Infrastructure.Services;
 /// </summary>
 public class ForumPostScraper : IForumPostScraper
 {
+    private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(2);
+    private static readonly Regex TitlePattern = new(
+        @"<title[^>]*>([^<]+)</title>",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled,
+        RegexTimeout);
+
     private readonly IForumSessionManager _sessionManager;
     private readonly IForumScraper _forumScraper;
     private readonly ILinkExtractorService _linkExtractor;
+    private readonly ILanguageTagParser _languageTagParser;
     private readonly IUrlValidator _urlValidator;
     private readonly IResponseValidator _responseValidator;
     private readonly ILogger<ForumPostScraper> _logger;
@@ -24,6 +32,7 @@ public class ForumPostScraper : IForumPostScraper
         IForumSessionManager sessionManager,
         IForumScraper forumScraper,
         ILinkExtractorService linkExtractor,
+        ILanguageTagParser languageTagParser,
         IUrlValidator urlValidator,
         IResponseValidator responseValidator,
         ILogger<ForumPostScraper> logger)
@@ -31,6 +40,7 @@ public class ForumPostScraper : IForumPostScraper
         _sessionManager = sessionManager ?? throw new ArgumentNullException(nameof(sessionManager));
         _forumScraper = forumScraper ?? throw new ArgumentNullException(nameof(forumScraper));
         _linkExtractor = linkExtractor ?? throw new ArgumentNullException(nameof(linkExtractor));
+        _languageTagParser = languageTagParser ?? throw new ArgumentNullException(nameof(languageTagParser));
         _urlValidator = urlValidator ?? throw new ArgumentNullException(nameof(urlValidator));
         _responseValidator = responseValidator ?? throw new ArgumentNullException(nameof(responseValidator));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -65,6 +75,19 @@ public class ForumPostScraper : IForumPostScraper
                 return PostScrapeResult.Failed(postUrl, "No post content found");
             }
 
+            // Parse language tags from the thread title
+            var threadTitle = ExtractThreadTitle(html);
+            var language = threadTitle is not null
+                ? _languageTagParser.GetLanguageString(threadTitle)
+                : null;
+
+            if (language is not null)
+            {
+                _logger.LogDebug(
+                    "Detected language '{Language}' from thread title '{Title}' at {PostUrl}",
+                    language, threadTitle, postUrl);
+            }
+
             // Extract links from all posts in the thread
             var allLinks = new List<Link>();
 
@@ -75,6 +98,15 @@ public class ForumPostScraper : IForumPostScraper
                 var links = await _linkExtractor.ExtractLinksAsync(
                     post.HtmlContent, runId, postUrl, ct);
                 allLinks.AddRange(links);
+            }
+
+            // Apply detected language to all extracted links
+            if (language is not null)
+            {
+                foreach (var link in allLinks)
+                {
+                    link.Language = language;
+                }
             }
 
             _logger.LogDebug(
@@ -132,5 +164,46 @@ public class ForumPostScraper : IForumPostScraper
         }
 
         return html;
+    }
+
+    /// <summary>
+    /// Extracts the thread title from the HTML page title element.
+    /// phpBB2 titles typically follow: "Forum Name :: View topic - Thread Title"
+    /// </summary>
+    internal static string? ExtractThreadTitle(string html)
+    {
+        if (string.IsNullOrWhiteSpace(html))
+            return null;
+
+        try
+        {
+            var match = TitlePattern.Match(html);
+            if (!match.Success)
+                return null;
+
+            var fullTitle = match.Groups[1].Value.Trim();
+
+            // phpBB2 pattern: "Forum Name :: View topic - Thread Title"
+            var viewTopicIndex = fullTitle.IndexOf("View topic -", StringComparison.OrdinalIgnoreCase);
+            if (viewTopicIndex >= 0)
+            {
+                var threadTitle = fullTitle[(viewTopicIndex + "View topic -".Length)..].Trim();
+                return string.IsNullOrEmpty(threadTitle) ? null : threadTitle;
+            }
+
+            // Generic fallback: remove "::"-separated prefix (common forum pattern)
+            var lastSeparator = fullTitle.LastIndexOf("::", StringComparison.Ordinal);
+            if (lastSeparator >= 0)
+            {
+                var threadTitle = fullTitle[(lastSeparator + 2)..].Trim();
+                return string.IsNullOrEmpty(threadTitle) ? null : threadTitle;
+            }
+
+            return fullTitle;
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            return null;
+        }
     }
 }

--- a/src/SeriesScraper.Web/Pages/Results.razor
+++ b/src/SeriesScraper.Web/Pages/Results.razor
@@ -170,6 +170,7 @@ else
                                                                     <th>Type</th>
                                                                     <th>URL</th>
                                                                     <th>S/E</th>
+                                                                    <th>Language</th>
                                                                     <th>Current</th>
                                                                 </tr>
                                                             </thead>
@@ -187,6 +188,7 @@ else
                                                                                 <text>S@(link.ParsedSeason?.ToString("D2") ?? "--")E@(link.ParsedEpisode?.ToString("D2") ?? "--")</text>
                                                                             }
                                                                         </td>
+                                                                        <td>@(link.Language ?? "—")</td>
                                                                         <td>
                                                                             @if (link.IsCurrent)
                                                                             {

--- a/src/SeriesScraper.Web/Program.cs
+++ b/src/SeriesScraper.Web/Program.cs
@@ -75,6 +75,7 @@ try
 
     // Singleton services
     builder.Services.AddSingleton<ILanguageDetector, LinguaLanguageDetector>();
+    builder.Services.AddSingleton<ILanguageTagParser, LanguageTagParser>();
     builder.Services.AddSingleton<IHtmlForumSectionParser, HtmlForumSectionParser>();
     builder.Services.AddSingleton<IResponseValidator, PhpBB2ResponseValidator>();
 

--- a/tests/SeriesScraper.Application.Tests/Services/LanguageTagParserTests.cs
+++ b/tests/SeriesScraper.Application.Tests/Services/LanguageTagParserTests.cs
@@ -1,0 +1,247 @@
+using FluentAssertions;
+using SeriesScraper.Application.Services;
+
+namespace SeriesScraper.Application.Tests.Services;
+
+public class LanguageTagParserTests
+{
+    private readonly LanguageTagParser _sut = new();
+
+    // ── ParseLanguageTags ────────────────────────────────────
+
+    [Fact]
+    public void ParseLanguageTags_NullInput_ReturnsEmpty()
+    {
+        _sut.ParseLanguageTags(null!).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ParseLanguageTags_EmptyInput_ReturnsEmpty()
+    {
+        _sut.ParseLanguageTags("").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ParseLanguageTags_WhitespaceInput_ReturnsEmpty()
+    {
+        _sut.ParseLanguageTags("   ").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ParseLanguageTags_NoSlash_ReturnsEmpty()
+    {
+        _sut.ParseLanguageTags("Some Movie Title").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ParseLanguageTags_SingleSlashWithLanguageCodes_ReturnsMapped()
+    {
+        var result = _sut.ParseLanguageTags("Tenkrát poprvé / CZ, EN");
+
+        result.Should().HaveCount(2);
+        result.Should().ContainInOrder("cs", "en");
+    }
+
+    [Fact]
+    public void ParseLanguageTags_MultipleSlashesWithLanguageCodes_ParsesLastSegment()
+    {
+        var result = _sut.ParseLanguageTags("Tenkrát poprvé / Never Have I Ever / CZ, EN");
+
+        result.Should().HaveCount(2);
+        result.Should().ContainInOrder("cs", "en");
+    }
+
+    [Fact]
+    public void ParseLanguageTags_SingleLanguageCode_ReturnsSingle()
+    {
+        var result = _sut.ParseLanguageTags("Čmuchalovci 2 / Bloodhounds /CZ");
+
+        result.Should().HaveCount(1);
+        result[0].Should().Be("cs");
+    }
+
+    [Fact]
+    public void ParseLanguageTags_InconsistentWhitespace_StillParses()
+    {
+        var result = _sut.ParseLanguageTags("Title /CZ,EN");
+
+        result.Should().HaveCount(2);
+        result.Should().ContainInOrder("cs", "en");
+    }
+
+    [Fact]
+    public void ParseLanguageTags_SpacesAroundCodes_TrimsProperly()
+    {
+        var result = _sut.ParseLanguageTags("Title / CZ , EN , SK ");
+
+        result.Should().HaveCount(3);
+        result.Should().ContainInOrder("cs", "en", "sk");
+    }
+
+    [Fact]
+    public void ParseLanguageTags_SlovakCode_MapsToSk()
+    {
+        var result = _sut.ParseLanguageTags("Title / SK");
+
+        result.Should().ContainSingle().Which.Should().Be("sk");
+    }
+
+    [Fact]
+    public void ParseLanguageTags_GermanCode_MapsToDe()
+    {
+        var result = _sut.ParseLanguageTags("Title / DE");
+
+        result.Should().ContainSingle().Which.Should().Be("de");
+    }
+
+    [Fact]
+    public void ParseLanguageTags_MixedCase_HandlesCorrectly()
+    {
+        var result = _sut.ParseLanguageTags("Title / cz, En, sk");
+
+        result.Should().HaveCount(3);
+        result.Should().ContainInOrder("cs", "en", "sk");
+    }
+
+    [Fact]
+    public void ParseLanguageTags_UnknownCode_ReturnsLowercased()
+    {
+        var result = _sut.ParseLanguageTags("Title / XX");
+
+        result.Should().ContainSingle().Which.Should().Be("xx");
+    }
+
+    [Fact]
+    public void ParseLanguageTags_LastSegmentNotCodes_ReturnsEmpty()
+    {
+        // If the last segment contains non-code text, treat it as not a language segment
+        var result = _sut.ParseLanguageTags("Title / Another Title / This is not a code");
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ParseLanguageTags_LastSegmentEmptyAfterSlash_ReturnsEmpty()
+    {
+        var result = _sut.ParseLanguageTags("Title / ");
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ParseLanguageTags_DuplicateCodes_Deduplicates()
+    {
+        var result = _sut.ParseLanguageTags("Title / CZ, CZ, EN");
+
+        result.Should().HaveCount(2);
+        result.Should().ContainInOrder("cs", "en");
+    }
+
+    [Fact]
+    public void ParseLanguageTags_UkraineCode_MapsToUk()
+    {
+        var result = _sut.ParseLanguageTags("Title / UA");
+
+        result.Should().ContainSingle().Which.Should().Be("uk");
+    }
+
+    [Fact]
+    public void ParseLanguageTags_JapaneseCode_MapsToJa()
+    {
+        var result = _sut.ParseLanguageTags("Title / JP");
+
+        result.Should().ContainSingle().Which.Should().Be("ja");
+    }
+
+    [Fact]
+    public void ParseLanguageTags_ThreeLetterCode_Accepted()
+    {
+        // Three-letter codes are valid per the regex
+        var result = _sut.ParseLanguageTags("Title / CZE");
+
+        result.Should().ContainSingle().Which.Should().Be("cze");
+    }
+
+    [Fact]
+    public void ParseLanguageTags_CodeWithNumbers_ReturnsEmpty()
+    {
+        // Codes with numbers are not valid country codes
+        var result = _sut.ParseLanguageTags("Title / C1, 2E");
+
+        result.Should().BeEmpty();
+    }
+
+    // ── GetLanguageString ────────────────────────────────────
+
+    [Fact]
+    public void GetLanguageString_NullInput_ReturnsNull()
+    {
+        _sut.GetLanguageString(null!).Should().BeNull();
+    }
+
+    [Fact]
+    public void GetLanguageString_NoTags_ReturnsNull()
+    {
+        _sut.GetLanguageString("Simple Title").Should().BeNull();
+    }
+
+    [Fact]
+    public void GetLanguageString_SingleCode_ReturnsIsoString()
+    {
+        _sut.GetLanguageString("Title / CZ").Should().Be("cs");
+    }
+
+    [Fact]
+    public void GetLanguageString_MultipleCodes_ReturnsCommaSeparated()
+    {
+        _sut.GetLanguageString("Title / CZ, EN").Should().Be("cs,en");
+    }
+
+    [Fact]
+    public void GetLanguageString_ThreeCodes_ReturnsCommaSeparated()
+    {
+        _sut.GetLanguageString("Title / CZ, EN, SK").Should().Be("cs,en,sk");
+    }
+
+    [Fact]
+    public void GetLanguageString_FullForumTitle_ParsesCorrectly()
+    {
+        _sut.GetLanguageString("Tenkrát poprvé / Never Have I Ever / CZ, EN").Should().Be("cs,en");
+    }
+
+    [Fact]
+    public void GetLanguageString_BloodhoundsExample_ParsesCorrectly()
+    {
+        _sut.GetLanguageString("Čmuchalovci 2 / Bloodhounds /CZ").Should().Be("cs");
+    }
+
+    // ── All mapped codes ────────────────────────────────────
+
+    [Theory]
+    [InlineData("CZ", "cs")]
+    [InlineData("SK", "sk")]
+    [InlineData("EN", "en")]
+    [InlineData("DE", "de")]
+    [InlineData("FR", "fr")]
+    [InlineData("ES", "es")]
+    [InlineData("IT", "it")]
+    [InlineData("PL", "pl")]
+    [InlineData("HU", "hu")]
+    [InlineData("RU", "ru")]
+    [InlineData("PT", "pt")]
+    [InlineData("NL", "nl")]
+    [InlineData("RO", "ro")]
+    [InlineData("HR", "hr")]
+    [InlineData("SR", "sr")]
+    [InlineData("BG", "bg")]
+    [InlineData("UA", "uk")]
+    [InlineData("JP", "ja")]
+    [InlineData("KR", "ko")]
+    [InlineData("CN", "zh")]
+    public void ParseLanguageTags_AllKnownMappings_MapCorrectly(string input, string expected)
+    {
+        var result = _sut.ParseLanguageTags($"Title / {input}");
+
+        result.Should().ContainSingle().Which.Should().Be(expected);
+    }
+}

--- a/tests/SeriesScraper.Infrastructure.Tests/Services/ForumPostScraperTests.cs
+++ b/tests/SeriesScraper.Infrastructure.Tests/Services/ForumPostScraperTests.cs
@@ -16,6 +16,7 @@ public class ForumPostScraperTests : IDisposable
     private readonly IForumSessionManager _sessionManager;
     private readonly IForumScraper _forumScraper;
     private readonly ILinkExtractorService _linkExtractor;
+    private readonly ILanguageTagParser _languageTagParser;
     private readonly IUrlValidator _urlValidator;
     private readonly IResponseValidator _responseValidator;
     private readonly ILogger<ForumPostScraper> _logger;
@@ -37,6 +38,7 @@ public class ForumPostScraperTests : IDisposable
         _sessionManager = Substitute.For<IForumSessionManager>();
         _forumScraper = Substitute.For<IForumScraper>();
         _linkExtractor = Substitute.For<ILinkExtractorService>();
+        _languageTagParser = Substitute.For<ILanguageTagParser>();
         _urlValidator = Substitute.For<IUrlValidator>();
         _responseValidator = Substitute.For<IResponseValidator>();
         _logger = Substitute.For<ILogger<ForumPostScraper>>();
@@ -59,7 +61,7 @@ public class ForumPostScraperTests : IDisposable
             return true;
         });
 
-        _sut = new ForumPostScraper(_sessionManager, _forumScraper, _linkExtractor, _urlValidator, _responseValidator, _logger);
+        _sut = new ForumPostScraper(_sessionManager, _forumScraper, _linkExtractor, _languageTagParser, _urlValidator, _responseValidator, _logger);
     }
 
     public void Dispose()
@@ -73,42 +75,42 @@ public class ForumPostScraperTests : IDisposable
     [Fact]
     public void Constructor_NullSessionManager_Throws()
     {
-        var act = () => new ForumPostScraper(null!, _forumScraper, _linkExtractor, _urlValidator, _responseValidator, _logger);
+        var act = () => new ForumPostScraper(null!, _forumScraper, _linkExtractor, _languageTagParser, _urlValidator, _responseValidator, _logger);
         act.Should().Throw<ArgumentNullException>().WithParameterName("sessionManager");
     }
 
     [Fact]
     public void Constructor_NullForumScraper_Throws()
     {
-        var act = () => new ForumPostScraper(_sessionManager, null!, _linkExtractor, _urlValidator, _responseValidator, _logger);
+        var act = () => new ForumPostScraper(_sessionManager, null!, _linkExtractor, _languageTagParser, _urlValidator, _responseValidator, _logger);
         act.Should().Throw<ArgumentNullException>().WithParameterName("forumScraper");
     }
 
     [Fact]
     public void Constructor_NullLinkExtractor_Throws()
     {
-        var act = () => new ForumPostScraper(_sessionManager, _forumScraper, null!, _urlValidator, _responseValidator, _logger);
+        var act = () => new ForumPostScraper(_sessionManager, _forumScraper, null!, _languageTagParser, _urlValidator, _responseValidator, _logger);
         act.Should().Throw<ArgumentNullException>().WithParameterName("linkExtractor");
     }
 
     [Fact]
     public void Constructor_NullUrlValidator_Throws()
     {
-        var act = () => new ForumPostScraper(_sessionManager, _forumScraper, _linkExtractor, null!, _responseValidator, _logger);
+        var act = () => new ForumPostScraper(_sessionManager, _forumScraper, _linkExtractor, _languageTagParser, null!, _responseValidator, _logger);
         act.Should().Throw<ArgumentNullException>().WithParameterName("urlValidator");
     }
 
     [Fact]
     public void Constructor_NullResponseValidator_Throws()
     {
-        var act = () => new ForumPostScraper(_sessionManager, _forumScraper, _linkExtractor, _urlValidator, null!, _logger);
+        var act = () => new ForumPostScraper(_sessionManager, _forumScraper, _linkExtractor, _languageTagParser, _urlValidator, null!, _logger);
         act.Should().Throw<ArgumentNullException>().WithParameterName("responseValidator");
     }
 
     [Fact]
     public void Constructor_NullLogger_Throws()
     {
-        var act = () => new ForumPostScraper(_sessionManager, _forumScraper, _linkExtractor, _urlValidator, _responseValidator, null!);
+        var act = () => new ForumPostScraper(_sessionManager, _forumScraper, _linkExtractor, _languageTagParser, _urlValidator, _responseValidator, null!);
         act.Should().Throw<ArgumentNullException>().WithParameterName("logger");
     }
 
@@ -468,6 +470,125 @@ public class ForumPostScraperTests : IDisposable
         result.Success.Should().BeTrue();
         await _sessionManager.DidNotReceive().RefreshSessionAsync(Arg.Any<Forum>(), Arg.Any<CancellationToken>());
     }
+
+    // --- #100: ExtractThreadTitle ---
+
+    [Fact]
+    public void ExtractThreadTitle_NullHtml_ReturnsNull()
+    {
+        ForumPostScraper.ExtractThreadTitle(null!).Should().BeNull();
+    }
+
+    [Fact]
+    public void ExtractThreadTitle_EmptyHtml_ReturnsNull()
+    {
+        ForumPostScraper.ExtractThreadTitle("").Should().BeNull();
+    }
+
+    [Fact]
+    public void ExtractThreadTitle_NoTitleTag_ReturnsNull()
+    {
+        ForumPostScraper.ExtractThreadTitle("<html><body>No title</body></html>").Should().BeNull();
+    }
+
+    [Fact]
+    public void ExtractThreadTitle_PhpBB2Title_ExtractsThreadTitle()
+    {
+        var html = "<html><head><title>Forum :: View topic - Tenkrát poprvé / Never Have I Ever / CZ, EN</title></head></html>";
+        ForumPostScraper.ExtractThreadTitle(html).Should().Be("Tenkrát poprvé / Never Have I Ever / CZ, EN");
+    }
+
+    [Fact]
+    public void ExtractThreadTitle_DoubleColonSeparator_ExtractsAfterLast()
+    {
+        var html = "<html><head><title>Forum Name :: Thread Title Here</title></head></html>";
+        ForumPostScraper.ExtractThreadTitle(html).Should().Be("Thread Title Here");
+    }
+
+    [Fact]
+    public void ExtractThreadTitle_SimpleTitleTag_ReturnsFull()
+    {
+        var html = "<html><head><title>Simple Page Title</title></head></html>";
+        ForumPostScraper.ExtractThreadTitle(html).Should().Be("Simple Page Title");
+    }
+
+    [Fact]
+    public void ExtractThreadTitle_ViewTopicCaseInsensitive_Extracts()
+    {
+        var html = "<html><head><title>Forum :: view topic - My Thread</title></head></html>";
+        ForumPostScraper.ExtractThreadTitle(html).Should().Be("My Thread");
+    }
+
+    // --- #100: Language integration in ScrapePostAsync ---
+
+    [Fact]
+    public async Task ScrapePostAsync_WithLanguageInTitle_SetsLanguageOnLinks()
+    {
+        var postUrl = "https://forum.example.com/thread/1";
+        var htmlWithTitle = "<html><head><title>Forum :: View topic - Čmuchalovci 2 / Bloodhounds / CZ, EN</title></head><body>Forum page</body></html>";
+
+        // Return HTML with a title containing language tags
+        _httpHandler.SetResponse(htmlWithTitle);
+
+        var posts = new List<PostContent>
+        {
+            new() { ThreadUrl = postUrl, PostIndex = 0, HtmlContent = "<p><a href='https://dl.example.com/file.mkv'>link</a></p>", PlainTextContent = "Post 1" }
+        };
+
+        _forumScraper.ExtractPostContentAsync(postUrl, Arg.Any<CancellationToken>())
+            .Returns(posts);
+
+        var link = new Link { Url = "https://dl.example.com/file.mkv", PostUrl = postUrl, LinkTypeId = 1, RunId = 1 };
+        _linkExtractor.ExtractLinksAsync(Arg.Any<string>(), 1, postUrl, Arg.Any<CancellationToken>())
+            .Returns(new List<Link> { link });
+
+        // Use real LanguageTagParser for integration-style test
+        _languageTagParser.GetLanguageString("Čmuchalovci 2 / Bloodhounds / CZ, EN").Returns("cs,en");
+
+        var result = await _sut.ScrapePostAsync(_testForum, postUrl, 1);
+
+        result.Success.Should().BeTrue();
+        result.ExtractedLinks.Should().HaveCount(1);
+        result.ExtractedLinks[0].Language.Should().Be("cs,en");
+    }
+
+    [Fact]
+    public async Task ScrapePostAsync_WithNoLanguageInTitle_LeavesLanguageNull()
+    {
+        var postUrl = "https://forum.example.com/thread/1";
+        var htmlWithTitle = "<html><head><title>Forum :: View topic - Simple Movie Title</title></head><body>Forum page</body></html>";
+
+        _httpHandler.SetResponse(htmlWithTitle);
+
+        var posts = new List<PostContent>
+        {
+            new() { ThreadUrl = postUrl, PostIndex = 0, HtmlContent = "<p><a href='https://dl.example.com/file.mkv'>link</a></p>", PlainTextContent = "Post 1" }
+        };
+
+        _forumScraper.ExtractPostContentAsync(postUrl, Arg.Any<CancellationToken>())
+            .Returns(posts);
+
+        var link = new Link { Url = "https://dl.example.com/file.mkv", PostUrl = postUrl, LinkTypeId = 1, RunId = 1 };
+        _linkExtractor.ExtractLinksAsync(Arg.Any<string>(), 1, postUrl, Arg.Any<CancellationToken>())
+            .Returns(new List<Link> { link });
+
+        _languageTagParser.GetLanguageString("Simple Movie Title").Returns((string?)null);
+
+        var result = await _sut.ScrapePostAsync(_testForum, postUrl, 1);
+
+        result.Success.Should().BeTrue();
+        result.ExtractedLinks.Should().HaveCount(1);
+        result.ExtractedLinks[0].Language.Should().BeNull();
+    }
+
+    // --- #100: Constructor null check for ILanguageTagParser ---
+
+    [Fact]
+    public void Constructor_NullLanguageTagParser_Throws()
+    {
+        var act = () => new ForumPostScraper(_sessionManager, _forumScraper, _linkExtractor, null!, _urlValidator, _responseValidator, _logger);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("languageTagParser");
+    }
 }
 
 /// <summary>
@@ -475,13 +596,18 @@ public class ForumPostScraperTests : IDisposable
 /// </summary>
 internal sealed class MockHttpMessageHandler : HttpMessageHandler
 {
-    private readonly string _responseContent;
+    private string _responseContent;
     private readonly HttpStatusCode _statusCode;
 
     public MockHttpMessageHandler(string responseContent, HttpStatusCode statusCode = HttpStatusCode.OK)
     {
         _responseContent = responseContent;
         _statusCode = statusCode;
+    }
+
+    public void SetResponse(string content)
+    {
+        _responseContent = content;
     }
 
     protected override Task<HttpResponseMessage> SendAsync(


### PR DESCRIPTION
Closes #100

## Summary
Adds language detection from forum thread titles to the Link entity. Thread titles encode language as a slash-separated suffix with country codes (e.g. \Tenkrát poprvé / Never Have I Ever / CZ, EN\). These are parsed and mapped to ISO 639-1 codes stored on each extracted link.

## Changes

### Domain Layer
- **Link.cs**: Added nullable \Language\ property (ISO 639-1, comma-separated for multiple languages)
- **ILanguageTagParser.cs**: New interface for parsing language tags from thread titles

### Application Layer
- **LanguageTagParser.cs**: Implementation that parses the last slash-separated segment for comma-separated country codes, maps 20 country codes to ISO 639-1 (CZ→cs, EN→en, SK→sk, etc.)
- **ResultsService.cs**: Maps \Language\ to \LinkDto\

### Infrastructure Layer
- **LinkConfiguration.cs**: Configured \Language\ column (varchar 50, nullable)
- **ForumPostScraper.cs**: Integrated language parsing — extracts thread title from HTML \<title>\ tag, parses language tags, applies to all extracted links
- **AddLanguageToLink migration**: EF Core migration for the new column

### Web Layer
- **Results.razor**: Added Language column to the link detail table
- **Program.cs**: Registered \ILanguageTagParser\ as singleton

## Testing
- 47 new tests for \LanguageTagParser\ (all code mappings, edge cases, null/empty handling)
- 10 new tests for \ForumPostScraper\ (\ExtractThreadTitle\ + language integration)
- All 536 tests pass

## Testing Notes
- Language parsing handles inconsistent whitespace around slashes
- Unknown country codes fall back to lowercase (e.g. XX → xx)
- If the last segment contains non-code tokens, no language is assigned (safe fallback)