### PR TITLE
feat(devops): Separate GitHub Actions runner into docker-compose.runner.yml

### DIFF
--- a/docker-compose.runner.yml
+++ b/docker-compose.runner.yml
@@ -1,0 +1,119 @@
+# ═════════════════════════════════════════════════════════════════════════════
+# GITHUB ACTIONS RUNNER COMPOSE FILE
+# ═════════════════════════════════════════════════════════════════════════════
+# This file contains the self-hosted GitHub Actions runner service.
+# It is separated from the main docker-compose.yml to avoid including CI/CD
+# infrastructure in end-user deployments.
+#
+# USAGE FOR DEVELOPMENT:
+#   docker compose -f docker-compose.yml -f docker-compose.runner.yml up -d
+#
+# USAGE FOR PRODUCTION (without runner):
+#   docker compose up -d
+#
+# See docs/infrastructure/GITHUB_RUNNER_SETUP.md for setup instructions.
+# ═════════════════════════════════════════════════════════════════════════════
+
+services:
+
+  # ─── Self-Hosted GitHub Actions Runner ────────────────────────────────────
+  # Registers with GitHub using a Personal Access Token (PAT) for persistence
+  # across container restarts. Configured for Docker-outside-of-Docker (DooD)
+  # to support Testcontainers in CI workflows.
+  #
+  # SECURITY WARNINGS:
+  # - Socket mount grants root-equivalent access to the host Docker daemon
+  # - Runner can spin up arbitrary containers with full host privileges
+  # - Only use in trusted environments with controlled GitHub access
+  # - Never expose this runner to public repositories
+  #
+  # Testcontainers Configuration:
+  # - DooD: Runner mounts host Docker socket, not nested daemon
+  # - Sibling containers: Testcontainers spins up PostgreSQL as sibling
+  # - TESTCONTAINERS_HOST_OVERRIDE: Allows runner to reach sibling containers
+  # - Ryuk: Resource reaper with Docker socket access for cleanup
+  github-runner:
+    # Pinned to specific version for security and reproducibility
+    # Version 2.320.0 corresponds to GitHub Actions runner v2.320.0
+    # To pin by digest instead, run:
+    #   docker manifest inspect myoung34/github-runner:2.320.0 | grep digest
+    # Update monthly to track GitHub Actions runner releases
+    image: myoung34/github-runner:2.320.0
+    environment:
+      # Repository URL for runner registration
+      REPO_URL: ${GITHUB_REPO_URL}
+      
+      # Personal Access Token (PAT) for runner registration
+      # REQUIRED: Fine-grained PAT with permissions: Actions (read/write)
+      # Unlike one-time RUNNER_TOKEN, this survives container restarts
+      ACCESS_TOKEN: ${GITHUB_ACCESS_TOKEN}
+      
+      # Runner display name in GitHub UI
+      RUNNER_NAME: ${RUNNER_NAME:-seriescraper-runner}
+      
+      # Working directory for GitHub Actions workflows
+      RUNNER_WORKDIR: /tmp/runner/work
+      
+      # Runner scope: 'repo' (not 'org' or 'enterprise')
+      RUNNER_SCOPE: repo
+      
+      # Labels for targeting workflows (must match runs-on in ci.yml)
+      LABELS: self-hosted
+      
+      # Testcontainers host override — allows runner container to reach
+      # sibling containers on the Docker host network
+      # Use 'host.docker.internal' (Windows/Mac) or 'host-gateway' (Linux)
+      # Linux Docker 20.10+: host-gateway resolves to host IP automatically
+      TESTCONTAINERS_HOST_OVERRIDE: ${TESTCONTAINERS_HOST_OVERRIDE:-host-gateway}
+      
+      # Ryuk (Testcontainers resource reaper) configuration
+      # Ryuk automatically cleans up orphaned containers after tests complete
+      # Requires Docker socket access (mounted below)
+      # Set to 'true' to disable Ryuk if cleanup is handled manually
+      TESTCONTAINERS_RYUK_DISABLED: ${TESTCONTAINERS_RYUK_DISABLED:-false}
+      
+      # Ryuk container image (override if using private registry)
+      # Default: testcontainers/ryuk:0.6.0
+      # TESTCONTAINERS_RYUK_CONTAINER_IMAGE: ${TESTCONTAINERS_RYUK_IMAGE:-testcontainers/ryuk:0.6.0}
+    
+    volumes:
+      # SECURITY CRITICAL: Docker-outside-of-Docker (DooD) socket mount
+      # Grants runner container access to the host Docker daemon
+      # This is equivalent to root access on the host machine
+      # Required for: Testcontainers, Docker builds in CI, docker compose commands
+      # Alternative: Docker-in-Docker (DinD) with increased overhead and complexity
+      - /var/run/docker.sock:/var/run/docker.sock
+      
+      # Persistent workspace for incremental builds and caching
+      - runner_work:/tmp/runner/work
+    
+    healthcheck:
+      # Verify the GitHub Actions Runner.Listener process is running
+      # The runner starts in ~30 seconds after registration completes
+      test: ["CMD-SHELL", "pgrep -f Runner.Listener || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+    
+    depends_on:
+      db:
+        condition: service_healthy
+    
+    restart: unless-stopped
+    
+    networks:
+      - seriescraper-network
+
+# ─── Volumes ────────────────────────────────────────────────────────────────
+volumes:
+  runner_work:
+    driver: local
+    # GitHub Actions workspace for self-hosted runner
+
+# ─── Networks ───────────────────────────────────────────────────────────────
+networks:
+  seriescraper-network:
+    driver: bridge
+    # Note: This network is shared with services in docker-compose.yml
+    # Docker Compose automatically merges networks with the same name

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,95 +71,6 @@ services:
     networks:
       - seriescraper-network
 
-  # ─── Self-Hosted GitHub Actions Runner ────────────────────────────────────
-  # Registers with GitHub using a Personal Access Token (PAT) for persistence
-  # across container restarts. Configured for Docker-outside-of-Docker (DooD)
-  # to support Testcontainers in CI workflows.
-  #
-  # SECURITY WARNINGS:
-  # - Socket mount grants root-equivalent access to the host Docker daemon
-  # - Runner can spin up arbitrary containers with full host privileges
-  # - Only use in trusted environments with controlled GitHub access
-  # - Never expose this runner to public repositories
-  #
-  # Testcontainers Configuration:
-  # - DooD: Runner mounts host Docker socket, not nested daemon
-  # - Sibling containers: Testcontainers spins up PostgreSQL as sibling
-  # - TESTCONTAINERS_HOST_OVERRIDE: Allows runner to reach sibling containers
-  # - Ryuk: Resource reaper with Docker socket access for cleanup
-  github-runner:
-    # Pinned to specific version for security and reproducibility
-    # Version 2.320.0 corresponds to GitHub Actions runner v2.320.0
-    # To pin by digest instead, run:
-    #   docker manifest inspect myoung34/github-runner:2.320.0 | grep digest
-    # Update monthly to track GitHub Actions runner releases
-    image: myoung34/github-runner:2.320.0
-    environment:
-      # Repository URL for runner registration
-      REPO_URL: ${GITHUB_REPO_URL}
-      
-      # Personal Access Token (PAT) for runner registration
-      # REQUIRED: Fine-grained PAT with permissions: Actions (read/write)
-      # Unlike one-time RUNNER_TOKEN, this survives container restarts
-      ACCESS_TOKEN: ${GITHUB_ACCESS_TOKEN}
-      
-      # Runner display name in GitHub UI
-      RUNNER_NAME: ${RUNNER_NAME:-seriescraper-runner}
-      
-      # Working directory for GitHub Actions workflows
-      RUNNER_WORKDIR: /tmp/runner/work
-      
-      # Runner scope: 'repo' (not 'org' or 'enterprise')
-      RUNNER_SCOPE: repo
-      
-      # Labels for targeting workflows (must match runs-on in ci.yml)
-      LABELS: self-hosted
-      
-      # Testcontainers host override — allows runner container to reach
-      # sibling containers on the Docker host network
-      # Use 'host.docker.internal' (Windows/Mac) or 'host-gateway' (Linux)
-      # Linux Docker 20.10+: host-gateway resolves to host IP automatically
-      TESTCONTAINERS_HOST_OVERRIDE: ${TESTCONTAINERS_HOST_OVERRIDE:-host-gateway}
-      
-      # Ryuk (Testcontainers resource reaper) configuration
-      # Ryuk automatically cleans up orphaned containers after tests complete
-      # Requires Docker socket access (mounted below)
-      # Set to 'true' to disable Ryuk if cleanup is handled manually
-      TESTCONTAINERS_RYUK_DISABLED: ${TESTCONTAINERS_RYUK_DISABLED:-false}
-      
-      # Ryuk container image (override if using private registry)
-      # Default: testcontainers/ryuk:0.6.0
-      # TESTCONTAINERS_RYUK_CONTAINER_IMAGE: ${TESTCONTAINERS_RYUK_IMAGE:-testcontainers/ryuk:0.6.0}
-    
-    volumes:
-      # SECURITY CRITICAL: Docker-outside-of-Docker (DooD) socket mount
-      # Grants runner container access to the host Docker daemon
-      # This is equivalent to root access on the host machine
-      # Required for: Testcontainers, Docker builds in CI, docker compose commands
-      # Alternative: Docker-in-Docker (DinD) with increased overhead and complexity
-      - /var/run/docker.sock:/var/run/docker.sock
-      
-      # Persistent workspace for incremental builds and caching
-      - runner_work:/tmp/runner/work
-    
-    healthcheck:
-      # Verify the GitHub Actions Runner.Listener process is running
-      # The runner starts in ~30 seconds after registration completes
-      test: ["CMD-SHELL", "pgrep -f Runner.Listener || exit 1"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 60s
-    
-    depends_on:
-      db:
-        condition: service_healthy
-    
-    restart: unless-stopped
-    
-    networks:
-      - seriescraper-network
-
 # ─── Volumes ────────────────────────────────────────────────────────────────
 volumes:
   postgres_data:
@@ -172,10 +83,6 @@ volumes:
     # Stores IMDB TSV files for non-commercial use
     # Expected size: 2-5 GB compressed, 5-10 GB uncompressed
     # Files: title.basics.tsv.gz, title.episode.tsv.gz, title.ratings.tsv.gz
-
-  runner_work:
-    driver: local
-    # GitHub Actions workspace for self-hosted runner
 
   app-logs:
     driver: local

--- a/docs/infrastructure/DOCKER_SETUP.md
+++ b/docs/infrastructure/DOCKER_SETUP.md
@@ -6,11 +6,22 @@ SeriesScraper uses Docker Compose to orchestrate the application stack for local
 
 ## Architecture
 
-The stack consists of three services:
+The stack consists of two core services:
 
 1. **app** - Blazor Server application (.NET 8)
 2. **db** - PostgreSQL 16 database (Alpine-based)
-3. **github-runner** - Self-hosted GitHub Actions runner for CI/CD
+
+For **local development and CI/CD**, an optional third service can be added:
+
+3. **github-runner** - Self-hosted GitHub Actions runner (see `docker-compose.runner.yml`)
+
+## Compose File Structure
+
+- `docker-compose.yml` - Core services (app + db) for production deployment
+- `docker-compose.runner.yml` - GitHub Actions runner for development/CI (optional)
+
+**Production**: Only `docker-compose.yml` is needed
+**Development**: Combine both files to include the CI runner
 
 ## Prerequisites
 
@@ -36,21 +47,37 @@ cp .env.example .env
   # Generate with:
   openssl rand -base64 32
   ```
-- `GITHUB_ACCESS_TOKEN` - From GitHub Settings → Actions → Runners → New runner
+- `GITHUB_ACCESS_TOKEN` - From GitHub Settings → Actions → Runners → New runner (only if using runner)
 - `FORUM_USERNAME` and `FORUM_PASSWORD` - Your forum credentials
 - `APP_ENV` - Set to `Development` for local dev, keep `Production` for deployment
 
 ### 2. Start Services
 
+**For production (app + database only)**:
 ```bash
-# Start all services in detached mode
 docker compose up -d
 
 # View logs
 docker compose logs -f
+```
+
+**For development with CI runner**:
+```bash
+# Start all services including GitHub Actions runner
+docker compose -f docker-compose.yml -f docker-compose.runner.yml up -d
+
+# View logs
+docker compose -f docker-compose.yml -f docker-compose.runner.yml logs -f
 
 # View logs for specific service
-docker compose logs -f app
+docker compose -f docker-compose.yml -f docker-compose.runner.yml logs -f app
+```
+
+**Note**: You can set `COMPOSE_FILE` environment variable to avoid repeating `-f` flags:
+```bash
+export COMPOSE_FILE=docker-compose.yml:docker-compose.runner.yml
+docker compose up -d
+docker compose logs -f
 ```
 
 ### 3. Verify Health
@@ -94,7 +121,9 @@ curl http://localhost:8080/healthz
 - **Volume**: `postgres_data` (5-15 GB depending on IMDB dataset)
 - **Security**: Loopback binding prevents network exposure
 
-### GitHub Actions Runner
+### GitHub Actions Runner (Optional - Development/CI Only)
+
+**Location**: `docker-compose.runner.yml` (separate file)
 
 - **Image**: `myoung34/github-runner:2.320.0` (pinned version for security)
 - **Purpose**: Runs CI/CD workflows locally on self-hosted infrastructure
@@ -109,7 +138,7 @@ curl http://localhost:8080/healthz
 **Quick Setup**:
 1. Generate GitHub fine-grained PAT with Actions (RW) + Administration (RW) permissions
 2. Add to `.env`: `GITHUB_ACCESS_TOKEN=ghp_your_token_here`
-3. Start runner: `docker compose up -d github-runner`
+3. Start runner: `docker compose -f docker-compose.yml -f docker-compose.runner.yml up -d github-runner`
 4. Verify in GitHub: Settings → Actions → Runners → `seriescraper-runner` should show **Idle** status
 
 ## Disk Usage
@@ -169,8 +198,11 @@ If deploying beyond localhost (NOT RECOMMENDED):
 ### Stopping Services
 
 ```bash
-# Stop all services
+# Stop all services (production mode)
 docker compose down
+
+# Stop all services including runner (development mode)
+docker compose -f docker-compose.yml -f docker-compose.runner.yml down
 
 # Stop and remove volumes (CAUTION: deletes all data)
 docker compose down -v
@@ -184,19 +216,28 @@ docker compose restart app
 
 # Rebuild and restart app after code changes
 docker compose up -d --build app
+
+# Restart runner (if using development setup)
+docker compose -f docker-compose.yml -f docker-compose.runner.yml restart github-runner
 ```
 
 ### Viewing Logs
 
 ```bash
-# All services
+# All services (production)
 docker compose logs -f
+
+# All services including runner (development)
+docker compose -f docker-compose.yml -f docker-compose.runner.yml logs -f
 
 # Specific service
 docker compose logs -f db
 
 # Last 100 lines
 docker compose logs --tail=100 app
+
+# Runner logs (development)
+docker compose -f docker-compose.yml -f docker-compose.runner.yml logs -f github-runner
 ```
 
 ### Database Access
@@ -267,8 +308,8 @@ docker compose exec app curl -f http://localhost:8080/healthz
 2. Regenerate token if expired: GitHub → Settings → Developer settings → Personal access tokens → Fine-grained tokens
 3. Ensure token has permissions: Actions (RW), Administration (RW)
 4. Update `.env` with new token
-5. Restart runner: `docker compose restart github-runner`
-6. Check runner logs: `docker compose logs github-runner`
+5. Restart runner: `docker compose -f docker-compose.yml -f docker-compose.runner.yml restart github-runner`
+6. Check runner logs: `docker compose -f docker-compose.yml -f docker-compose.runner.yml logs github-runner`
 7. Verify runner appears in GitHub: Settings → Actions → Runners
 
 For detailed troubleshooting, see [GITHUB_RUNNER_SETUP.md](GITHUB_RUNNER_SETUP.md).

--- a/docs/infrastructure/GITHUB_RUNNER_SETUP.md
+++ b/docs/infrastructure/GITHUB_RUNNER_SETUP.md
@@ -11,13 +11,16 @@ SeriesScraper uses a self-hosted GitHub Actions runner to execute CI/CD workflow
 
 ## Architecture
 
-The runner is deployed as a Docker container within the docker-compose stack:
+The runner is deployed as a Docker container via a separate compose file:
 
+- **Compose File**: `docker-compose.runner.yml` (separate from main stack)
 - **Image**: `myoung34/github-runner:2.320.0` (pinned for reproducibility)
 - **Configuration**: Docker-outside-of-Docker (DooD) with host socket mount
 - **Scope**: Repository-level runner (not organization or enterprise)
 - **Labels**: `self-hosted` (matches `runs-on` in workflow files)
 - **Network**: Connected to `seriescraper-network` for service communication
+
+**Note**: The runner is intentionally separated from `docker-compose.yml` to keep CI/CD infrastructure out of production deployments.
 
 ## Security Model
 
@@ -111,10 +114,14 @@ TESTCONTAINERS_RYUK_DISABLED=false
 
 ```bash
 # Start all services including the runner
+docker compose -f docker-compose.yml -f docker-compose.runner.yml up -d
+
+# Or use COMPOSE_FILE environment variable for convenience
+export COMPOSE_FILE=docker-compose.yml:docker-compose.runner.yml
 docker compose up -d
 
 # View runner logs to verify registration
-docker compose logs -f github-runner
+docker compose -f docker-compose.yml -f docker-compose.runner.yml logs -f github-runner
 ```
 
 **Expected Output**:
@@ -130,7 +137,7 @@ github-runner  | Runner.Listener started
 3. Verify status: **Idle** (green circle)
 
 **Troubleshooting**: If runner shows **Offline**:
-- Check logs: `docker compose logs github-runner`
+- Check logs: `docker compose -f docker-compose.yml -f docker-compose.runner.yml logs github-runner`
 - Verify `GITHUB_ACCESS_TOKEN` has correct permissions
 - Ensure `GITHUB_REPO_URL` matches your repository URL exactly
 - Token may have expired — regenerate and update `.env`
@@ -155,7 +162,7 @@ The runner container includes a health check that verifies the `Runner.Listener`
 
 ```bash
 # Check health status
-docker compose ps github-runner
+docker compose -f docker-compose.yml -f docker-compose.runner.yml ps github-runner
 
 # Expected output:
 # NAME                  STATUS                    PORTS
@@ -170,7 +177,7 @@ docker compose ps github-runner
 - **Start Period**: 60 seconds (runner registration time)
 
 **Unhealthy Status**: If the runner shows `(unhealthy)`:
-1. Check logs: `docker compose logs github-runner`
+1. Check logs: `docker compose -f docker-compose.yml -f docker-compose.runner.yml logs github-runner`
 2. Common causes:
    - Token expired or invalid
    - Network connectivity issues
@@ -219,10 +226,10 @@ Run the integration tests locally to verify the setup:
 
 ```bash
 # Start the runner
-docker compose up -d github-runner
+docker compose -f docker-compose.yml -f docker-compose.runner.yml up -d github-runner
 
 # Trigger a test workflow or run tests manually inside the runner
-docker compose exec github-runner bash
+docker compose -f docker-compose.yml -f docker-compose.runner.yml exec github-runner bash
 # Inside runner container:
 cd /tmp/runner/work/SeriesScraper/SeriesScraper
 dotnet test --filter Category=Integration
@@ -241,31 +248,31 @@ exit
 
 ```bash
 # Restart just the runner service
-docker compose restart github-runner
+docker compose -f docker-compose.yml -f docker-compose.runner.yml restart github-runner
 
 # Rebuild and restart (after updating environment variables)
-docker compose up -d --build github-runner
+docker compose -f docker-compose.yml -f docker-compose.runner.yml up -d --build github-runner
 ```
 
 ### View Runner Logs
 
 ```bash
 # Live tail
-docker compose logs -f github-runner
+docker compose -f docker-compose.yml -f docker-compose.runner.yml logs -f github-runner
 
 # Last 100 lines
-docker compose logs --tail=100 github-runner
+docker compose -f docker-compose.yml -f docker-compose.runner.yml logs --tail=100 github-runner
 
 # Export logs for debugging
-docker compose logs github-runner > runner-debug.log
+docker compose -f docker-compose.yml -f docker-compose.runner.yml logs github-runner > runner-debug.log
 ```
 
 ### Deregister the Runner
 
 ```bash
 # Stop and remove the runner container
-docker compose stop github-runner
-docker compose rm -f github-runner
+docker compose -f docker-compose.yml -f docker-compose.runner.yml stop github-runner
+docker compose -f docker-compose.yml -f docker-compose.runner.yml rm -f github-runner
 
 # Remove the runner from GitHub UI
 # Navigate to: Settings → Actions → Runners → Click '...' → Remove
@@ -280,7 +287,7 @@ docker compose rm -f github-runner
 docker pull myoung34/github-runner:2.320.0
 
 # Recreate the runner with the new image
-docker compose up -d --build github-runner
+docker compose -f docker-compose.yml -f docker-compose.runner.yml up -d --build github-runner
 ```
 
 **Warning**: Always test runner updates on a non-main branch before deploying to production.
@@ -292,9 +299,9 @@ docker compose up -d --build github-runner
 **Symptoms**: Runner appears in GitHub but status is Offline (gray circle)
 
 **Causes & Solutions**:
-1. **Token Expired**: Regenerate PAT and update `.env`, then `docker compose restart github-runner`
+1. **Token Expired**: Regenerate PAT and update `.env`, then `docker compose -f docker-compose.yml -f docker-compose.runner.yml restart github-runner`
 2. **Wrong Repository URL**: Verify `GITHUB_REPO_URL` matches exactly (no trailing slash)
-3. **Network Issues**: Check Docker network connectivity: `docker compose exec github-runner ping github.com`
+3. **Network Issues**: Check Docker network connectivity: `docker compose -f docker-compose.yml -f docker-compose.runner.yml exec github-runner ping github.com`
 4. **Rate Limiting**: GitHub API rate limit exceeded — wait 1 hour
 
 ### Workflows Not Running on Self-Hosted Runner
@@ -304,14 +311,14 @@ docker compose up -d --build github-runner
 **Causes & Solutions**:
 1. **Label Mismatch**: Verify workflow has `runs-on: self-hosted` (not `runs-on: ubuntu-latest`)
 2. **Runner Offline**: Check runner status in GitHub Settings → Actions → Runners
-3. **Runner Busy**: Check `docker compose logs github-runner` for active jobs
+3. **Runner Busy**: Check `docker compose -f docker-compose.yml -f docker-compose.runner.yml logs github-runner` for active jobs
 
 ### Tests Fail with "Cannot Connect to Docker Daemon"
 
 **Symptoms**: Testcontainers throws `DockerException: Cannot connect to Docker daemon`
 
 **Causes & Solutions**:
-1. **Socket Not Mounted**: Verify `/var/run/docker.sock:/var/run/docker.sock` in `docker-compose.yml`
+1. **Socket Not Mounted**: Verify `/var/run/docker.sock:/var/run/docker.sock` in `docker-compose.runner.yml`
 2. **Socket Permissions**: On Linux, ensure user is in `docker` group
 3. **Windows/Mac**: Restart Docker Desktop
 
@@ -344,8 +351,8 @@ docker compose up -d --build github-runner
 
 ### After Docker Engine Updates
 
-- [ ] Restart runner: `docker compose restart github-runner`
-- [ ] Verify health check passes: `docker compose ps`
+- [ ] Restart runner: `docker compose -f docker-compose.yml -f docker-compose.runner.yml restart github-runner`
+- [ ] Verify health check passes: `docker compose -f docker-compose.yml -f docker-compose.runner.yml ps`
 - [ ] Run a test workflow to confirm functionality
 
 ### Before Major Changes (e.g., Workflow Modifications)


### PR DESCRIPTION
Closes #105

## Summary
Separated the GitHub Actions runner service from docker-compose.yml into a dedicated docker-compose.runner.yml file to keep CI/CD infrastructure out of production deployments.

## Changes
- ✅ Created docker-compose.runner.yml containing the github-runner service
- ✅ Removed github-runner service from main docker-compose.yml
- ✅ Removed unner_work volume from main docker-compose.yml
- ✅ Updated docs/infrastructure/DOCKER_SETUP.md to document separate compose files
- ✅ Updated docs/infrastructure/GITHUB_RUNNER_SETUP.md with new usage patterns

## Rationale
The GitHub Actions runner is a development/CI concern and should not be part of end-user production deployments. Separating it into a dedicated compose file allows:

**Production**: Use only docker-compose.yml (app + db)
\\\ash
docker compose up -d
\\\

**Development**: Combine both files for full stack + CI
\\\ash
docker compose -f docker-compose.yml -f docker-compose.runner.yml up -d
\\\

## Testing
- [ ] Verify production stack starts with \docker compose up -d\ (no runner)
- [ ] Verify development stack starts with both files (includes runner)
- [ ] Verify runner registers successfully with GitHub in development mode
- [ ] CI workflow passes on this branch

## Files Changed
- \docker-compose.runner.yml\ (new)
- \docker-compose.yml\ (modified)
- \docs/infrastructure/DOCKER_SETUP.md\ (modified)
- \docs/infrastructure/GITHUB_RUNNER_SETUP.md\ (modified)

## Agent Labels
/label type:infrastructure
/label agent:devops
/label priority:medium