### PR TITLE
feat(#89): Playwright headless auth for reCAPTCHA v3 + manual cookie fallback

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,19 +16,38 @@
 # ═══════════════════════════════════════════════════════════════════════════
 
 # ─── Base Runtime Image ────────────────────────────────────────────────────
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
 EXPOSE 8080
 
-# Install curl for health checks (health check uses curl -f http://localhost:8080/healthz)
-RUN apk add --no-cache curl icu-libs
+# Install curl for health checks + Playwright Chromium dependencies (#89)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    libnss3 \
+    libatk1.0-0 \
+    libatk-bridge2.0-0 \
+    libcups2 \
+    libdrm2 \
+    libxkbcommon0 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxfixes3 \
+    libxrandr2 \
+    libgbm1 \
+    libpango-1.0-0 \
+    libcairo2 \
+    libasound2 \
+    libatspi2.0-0 \
+    libwayland-client0 \
+    fonts-liberation \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV ASPNETCORE_URLS=http://+:8080
 ENV DOTNET_RUNNING_IN_CONTAINER=true
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
 
 # ─── Build Image ───────────────────────────────────────────────────────────
-FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 
 # Copy solution file and all project files for dependency caching
@@ -69,9 +88,13 @@ WORKDIR /app
 # Copy published application from publish stage
 COPY --from=publish /app/publish .
 
+# Install Playwright Chromium browser for reCAPTCHA v3 authentication (#89)
+# Uses the Playwright CLI from the published app to install browsers
+RUN dotnet Microsoft.Playwright.dll install chromium
+
 # Create non-root user for security (principle of least privilege)
-RUN addgroup -g 1001 -S appgroup \
-    && adduser -u 1001 -S appuser -G appgroup \
+RUN addgroup --gid 1001 appgroup \
+    && adduser --uid 1001 --ingroup appgroup --disabled-password --gecos "" appuser \
     && chown -R appuser:appgroup /app
 
 # Create directories for persistent data with correct permissions

--- a/Dockerfile
+++ b/Dockerfile
@@ -89,8 +89,11 @@ WORKDIR /app
 COPY --from=publish /app/publish .
 
 # Install Playwright Chromium browser for reCAPTCHA v3 authentication (#89)
-# Uses the Playwright CLI from the published app to install browsers
-RUN dotnet Microsoft.Playwright.dll install chromium
+# Set PLAYWRIGHT_BROWSERS_PATH to a world-accessible path BEFORE install so that
+# when the app later runs as appuser it can find the browsers.
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+RUN dotnet Microsoft.Playwright.dll install chromium \
+    && chmod -R 755 /ms-playwright
 
 # Create non-root user for security (principle of least privilege)
 RUN addgroup --gid 1001 appgroup \

--- a/src/SeriesScraper.Application/Services/ForumSessionManager.cs
+++ b/src/SeriesScraper.Application/Services/ForumSessionManager.cs
@@ -295,7 +295,14 @@ public sealed class ForumSessionManager : IForumSessionManager
 
             var name = part[..eqIndex].Trim();
             var value = part[(eqIndex + 1)..].Trim();
-            container.Add(new Cookie(name, value, "/", domain));
+            try
+            {
+                container.Add(new Cookie(name, value, "/", domain));
+            }
+            catch (CookieException ex)
+            {
+                _logger.LogWarning(ex, "Skipping invalid manual cookie for forum {ForumId}", forumId);
+            }
         }
 
         return container;

--- a/src/SeriesScraper.Application/Services/ForumSessionManager.cs
+++ b/src/SeriesScraper.Application/Services/ForumSessionManager.cs
@@ -305,6 +305,10 @@ public sealed class ForumSessionManager : IForumSessionManager
             }
         }
 
+        var cookieUri = new Uri(baseUrl);
+        if (container.GetCookies(cookieUri).Count == 0)
+            return null;
+
         return container;
     }
 

--- a/src/SeriesScraper.Application/Services/ForumSessionManager.cs
+++ b/src/SeriesScraper.Application/Services/ForumSessionManager.cs
@@ -11,12 +11,18 @@ namespace SeriesScraper.Application.Services;
 /// Manages authenticated forum sessions with cookie-based persistence.
 /// Thread-safe: uses SemaphoreSlim per forum to serialize authentication
 /// while allowing concurrent reads of established sessions.
+/// Authentication strategy order:
+///   1. Manual cookie injection (setting key "forum.{id}.session_cookie")
+///   2. Playwright headless browser (handles reCAPTCHA v3)
+///   3. IForumScraper.AuthenticateAsync (fallback for forums without reCAPTCHA)
 /// </summary>
 public sealed class ForumSessionManager : IForumSessionManager
 {
     private readonly IForumScraper _forumScraper;
     private readonly IForumCredentialService _credentialService;
     private readonly ILogger<ForumSessionManager> _logger;
+    private readonly IPlaywrightAuthenticator? _playwrightAuthenticator;
+    private readonly ISettingRepository? _settingRepository;
 
     private readonly ConcurrentDictionary<int, SessionState> _sessions = new();
     private readonly ConcurrentDictionary<int, SemaphoreSlim> _locks = new();
@@ -24,6 +30,13 @@ public sealed class ForumSessionManager : IForumSessionManager
 
     private readonly TimeSpan _defaultSessionDuration;
     private bool _disposed;
+
+    /// <summary>
+    /// Setting key prefix for manual session cookie injection.
+    /// Full key format: "forum.{forumId}.session_cookie"
+    /// </summary>
+    internal const string ManualCookieSettingPrefix = "forum.";
+    internal const string ManualCookieSettingSuffix = ".session_cookie";
 
     /// <summary>
     /// Creates a new ForumSessionManager.
@@ -35,16 +48,22 @@ public sealed class ForumSessionManager : IForumSessionManager
     /// Default session duration when no explicit expiry is known.
     /// If null, defaults to 30 minutes.
     /// </param>
+    /// <param name="playwrightAuthenticator">Optional Playwright authenticator for reCAPTCHA-protected forums.</param>
+    /// <param name="settingRepository">Optional setting repository for manual cookie injection.</param>
     public ForumSessionManager(
         IForumScraper forumScraper,
         IForumCredentialService credentialService,
         ILogger<ForumSessionManager> logger,
-        TimeSpan? defaultSessionDuration = null)
+        TimeSpan? defaultSessionDuration = null,
+        IPlaywrightAuthenticator? playwrightAuthenticator = null,
+        ISettingRepository? settingRepository = null)
     {
         _forumScraper = forumScraper ?? throw new ArgumentNullException(nameof(forumScraper));
         _credentialService = credentialService ?? throw new ArgumentNullException(nameof(credentialService));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _defaultSessionDuration = defaultSessionDuration ?? TimeSpan.FromMinutes(30);
+        _playwrightAuthenticator = playwrightAuthenticator;
+        _settingRepository = settingRepository;
     }
 
     /// <inheritdoc />
@@ -142,6 +161,19 @@ public sealed class ForumSessionManager : IForumSessionManager
 
     private async Task AuthenticateInternalAsync(Forum forum, CancellationToken cancellationToken)
     {
+        // Strategy 1: Manual cookie injection (operator-provided session cookie)
+        var manualCookie = await TryGetManualCookieAsync(forum.ForumId, forum.BaseUrl, cancellationToken);
+        if (manualCookie is not null)
+        {
+            _logger.LogInformation(
+                "Using manually injected session cookie for forum {ForumId} ({ForumName})",
+                forum.ForumId, forum.Name);
+            EstablishSession(forum, manualCookie);
+            await DismissAgeVerificationAsync(_clients[forum.ForumId], forum, cancellationToken);
+            return;
+        }
+
+        // Resolve credentials (needed for both Playwright and IForumScraper fallback)
         var password = _credentialService.ResolveCredential(forum.CredentialKey);
         if (password is null)
         {
@@ -158,8 +190,35 @@ public sealed class ForumSessionManager : IForumSessionManager
             Password = password
         };
 
+        // Strategy 2: Playwright headless browser (handles reCAPTCHA v3)
+        if (_playwrightAuthenticator is not null)
+        {
+            try
+            {
+                _logger.LogInformation(
+                    "Attempting Playwright authentication for forum {ForumId} ({ForumName}) as {Username}",
+                    forum.ForumId, forum.Name, forum.Username);
+
+                var loginUrl = forum.BaseUrl.TrimEnd('/') + "/login.php";
+                var cookieContainer = await _playwrightAuthenticator.AuthenticateAsync(
+                    loginUrl, credentials, cancellationToken);
+
+                EstablishSession(forum, cookieContainer);
+                await DismissAgeVerificationAsync(_clients[forum.ForumId], forum, cancellationToken);
+                return;
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "Playwright authentication failed for forum {ForumId} ({ForumName}) — falling back to IForumScraper",
+                    forum.ForumId, forum.Name);
+            }
+        }
+
+        // Strategy 3: IForumScraper fallback (direct HTTP login, no reCAPTCHA support)
         _logger.LogInformation(
-            "Authenticating to forum {ForumId} ({ForumName}) as {Username}",
+            "Authenticating to forum {ForumId} ({ForumName}) as {Username} via IForumScraper",
             forum.ForumId, forum.Name, forum.Username);
 
         var success = await _forumScraper.AuthenticateAsync(credentials, cancellationToken);
@@ -172,8 +231,13 @@ public sealed class ForumSessionManager : IForumSessionManager
                 $"Authentication failed for forum '{forum.Name}' with username '{forum.Username}'.");
         }
 
-        // Use the scraper's CookieContainer so auth cookies are shared
-        var cookieContainer = _forumScraper.GetCookieContainer();
+        var scraperCookies = _forumScraper.GetCookieContainer();
+        EstablishSession(forum, scraperCookies);
+        await DismissAgeVerificationAsync(_clients[forum.ForumId], forum, cancellationToken);
+    }
+
+    private void EstablishSession(Forum forum, CookieContainer cookieContainer)
+    {
         var handler = new HttpClientHandler
         {
             CookieContainer = cookieContainer,
@@ -184,9 +248,6 @@ public sealed class ForumSessionManager : IForumSessionManager
         {
             BaseAddress = new Uri(forum.BaseUrl)
         };
-
-        // Dismiss age verification overlay (phpBB2 Warforum one-time 18+ check)
-        await DismissAgeVerificationAsync(client, forum, cancellationToken);
 
         // Dispose old client if it exists
         if (_clients.TryRemove(forum.ForumId, out var oldClient))
@@ -208,6 +269,36 @@ public sealed class ForumSessionManager : IForumSessionManager
         _logger.LogInformation(
             "Session established for forum {ForumId} ({ForumName}), expires at {ExpiresAt}",
             forum.ForumId, forum.Name, sessionState.ExpiresAtUtc);
+    }
+
+    private async Task<CookieContainer?> TryGetManualCookieAsync(int forumId, string baseUrl, CancellationToken cancellationToken)
+    {
+        if (_settingRepository is null)
+            return null;
+
+        var key = $"{ManualCookieSettingPrefix}{forumId}{ManualCookieSettingSuffix}";
+        var cookieValue = await _settingRepository.GetValueAsync(key, cancellationToken);
+
+        if (string.IsNullOrWhiteSpace(cookieValue))
+            return null;
+
+        _logger.LogDebug("Found manual session cookie setting for forum {ForumId}", forumId);
+
+        var domain = new Uri(baseUrl).Host;
+        var container = new CookieContainer();
+        // Parse cookie string: "name=value; name2=value2" format
+        foreach (var part in cookieValue.Split(';', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
+        {
+            var eqIndex = part.IndexOf('=');
+            if (eqIndex <= 0)
+                continue;
+
+            var name = part[..eqIndex].Trim();
+            var value = part[(eqIndex + 1)..].Trim();
+            container.Add(new Cookie(name, value, "/", domain));
+        }
+
+        return container;
     }
 
     private async Task DismissAgeVerificationAsync(HttpClient client, Forum forum, CancellationToken cancellationToken)

--- a/src/SeriesScraper.Domain/Interfaces/IPlaywrightAuthenticator.cs
+++ b/src/SeriesScraper.Domain/Interfaces/IPlaywrightAuthenticator.cs
@@ -1,0 +1,29 @@
+using System.Net;
+using SeriesScraper.Domain.ValueObjects;
+
+namespace SeriesScraper.Domain.Interfaces;
+
+/// <summary>
+/// Authenticates against a forum using a headless browser (Playwright).
+/// Required for forums that use reCAPTCHA v3 on the login form,
+/// where a standard HTTP POST cannot supply the g-recaptcha-response token.
+/// The headless browser loads the login page, executes the site's reCAPTCHA
+/// script automatically, then submits the form.
+/// </summary>
+public interface IPlaywrightAuthenticator : IAsyncDisposable
+{
+    /// <summary>
+    /// Authenticates by driving a headless browser to the forum login page,
+    /// filling in credentials, and submitting the form.
+    /// Returns the session cookies (especially warforum_sid) on success.
+    /// </summary>
+    /// <param name="loginUrl">Full URL to the forum login page.</param>
+    /// <param name="credentials">Forum username and password.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>CookieContainer with the authenticated session cookies.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when browser login fails.</exception>
+    Task<CookieContainer> AuthenticateAsync(
+        string loginUrl,
+        ForumCredentials credentials,
+        CancellationToken cancellationToken = default);
+}

--- a/src/SeriesScraper.Infrastructure/SeriesScraper.Infrastructure.csproj
+++ b/src/SeriesScraper.Infrastructure/SeriesScraper.Infrastructure.csproj
@@ -16,6 +16,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Playwright" Version="1.52.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.*" />
     <PackageReference Include="SearchPioneer.Lingua" Version="1.0.5" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.*" />

--- a/src/SeriesScraper.Infrastructure/Services/IPlaywrightFactory.cs
+++ b/src/SeriesScraper.Infrastructure/Services/IPlaywrightFactory.cs
@@ -1,0 +1,12 @@
+using Microsoft.Playwright;
+
+namespace SeriesScraper.Infrastructure.Services;
+
+/// <summary>
+/// Abstracts Playwright instance creation to enable unit testing of
+/// classes that depend on IPlaywright.
+/// </summary>
+public interface IPlaywrightFactory
+{
+    Task<IPlaywright> CreateAsync();
+}

--- a/src/SeriesScraper.Infrastructure/Services/PlaywrightAuthenticator.cs
+++ b/src/SeriesScraper.Infrastructure/Services/PlaywrightAuthenticator.cs
@@ -11,11 +11,14 @@ namespace SeriesScraper.Infrastructure.Services;
 /// Solves the reCAPTCHA v3 problem: the site's script auto-generates the
 /// g-recaptcha-response token when the form is submitted in a real browser.
 /// After login, session cookies are extracted and returned for use with HttpClient.
-/// The browser is disposed immediately after authentication.
+/// Each call creates a fresh IPlaywright instance — browser is short-lived and never
+/// cached as a singleton field, which avoids thread-safety races.
 /// </summary>
 public sealed class PlaywrightAuthenticator : IPlaywrightAuthenticator
 {
     private readonly ILogger<PlaywrightAuthenticator> _logger;
+    private readonly IPlaywrightFactory _playwrightFactory;
+    private readonly TimeSpan _postLoginWait;
 
     // Selector constants for the phpBB2 login form
     internal const string UsernameSelector = "input[name='username']";
@@ -23,16 +26,30 @@ public sealed class PlaywrightAuthenticator : IPlaywrightAuthenticator
     internal const string SubmitSelector = "input[name='login'], input[type='submit']";
     internal const string SessionCookieName = "warforum_sid";
 
-    // Timeouts
     private static readonly TimeSpan NavigationTimeout = TimeSpan.FromSeconds(30);
-    private static readonly TimeSpan PostLoginWait = TimeSpan.FromSeconds(5);
 
-    private IPlaywright? _playwright;
     private bool _disposed;
 
-    public PlaywrightAuthenticator(ILogger<PlaywrightAuthenticator> logger)
+    /// <summary>Primary constructor used by the DI container.</summary>
+    public PlaywrightAuthenticator(
+        ILogger<PlaywrightAuthenticator> logger,
+        IPlaywrightFactory playwrightFactory)
+        : this(logger, playwrightFactory, TimeSpan.FromSeconds(5))
+    {
+    }
+
+    /// <summary>
+    /// Constructor that allows injecting a custom post-login wait duration.
+    /// Intended for unit tests to avoid the full 5-second wait.
+    /// </summary>
+    internal PlaywrightAuthenticator(
+        ILogger<PlaywrightAuthenticator> logger,
+        IPlaywrightFactory playwrightFactory,
+        TimeSpan postLoginWait)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _playwrightFactory = playwrightFactory ?? throw new ArgumentNullException(nameof(playwrightFactory));
+        _postLoginWait = postLoginWait;
     }
 
     /// <inheritdoc />
@@ -49,12 +66,12 @@ public sealed class PlaywrightAuthenticator : IPlaywrightAuthenticator
             "Starting Playwright authentication for {LoginUrl} as {Username}",
             loginUrl, credentials.Username);
 
-        _playwright ??= await Playwright.CreateAsync();
-
+        // Create a fresh IPlaywright per call — never cached as a singleton field.
+        var playwright = await _playwrightFactory.CreateAsync();
         IBrowser? browser = null;
         try
         {
-            browser = await _playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+            browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
             {
                 Headless = true
             });
@@ -99,7 +116,7 @@ public sealed class PlaywrightAuthenticator : IPlaywrightAuthenticator
             }
 
             // Brief wait for any async cookie setting
-            await Task.Delay(PostLoginWait, cancellationToken);
+            await Task.Delay(_postLoginWait, cancellationToken);
 
             // Extract cookies
             var playwrightCookies = await context.CookiesAsync();
@@ -155,23 +172,16 @@ public sealed class PlaywrightAuthenticator : IPlaywrightAuthenticator
             {
                 await browser.CloseAsync();
             }
+
+            // Dispose the per-call playwright instance — never cache it
+            playwright.Dispose();
         }
     }
 
     /// <inheritdoc />
-    public async ValueTask DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        if (_disposed)
-            return;
-
         _disposed = true;
-
-        if (_playwright is not null)
-        {
-            _playwright.Dispose();
-            _playwright = null;
-        }
-
-        await ValueTask.CompletedTask;
+        return ValueTask.CompletedTask;
     }
 }

--- a/src/SeriesScraper.Infrastructure/Services/PlaywrightAuthenticator.cs
+++ b/src/SeriesScraper.Infrastructure/Services/PlaywrightAuthenticator.cs
@@ -1,0 +1,177 @@
+using System.Net;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+using SeriesScraper.Domain.Interfaces;
+using SeriesScraper.Domain.ValueObjects;
+
+namespace SeriesScraper.Infrastructure.Services;
+
+/// <summary>
+/// Authenticates against a forum by driving a headless Chromium browser via Playwright.
+/// Solves the reCAPTCHA v3 problem: the site's script auto-generates the
+/// g-recaptcha-response token when the form is submitted in a real browser.
+/// After login, session cookies are extracted and returned for use with HttpClient.
+/// The browser is disposed immediately after authentication.
+/// </summary>
+public sealed class PlaywrightAuthenticator : IPlaywrightAuthenticator
+{
+    private readonly ILogger<PlaywrightAuthenticator> _logger;
+
+    // Selector constants for the phpBB2 login form
+    internal const string UsernameSelector = "input[name='username']";
+    internal const string PasswordSelector = "input[name='password']";
+    internal const string SubmitSelector = "input[name='login'], input[type='submit']";
+    internal const string SessionCookieName = "warforum_sid";
+
+    // Timeouts
+    private static readonly TimeSpan NavigationTimeout = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan PostLoginWait = TimeSpan.FromSeconds(5);
+
+    private IPlaywright? _playwright;
+    private bool _disposed;
+
+    public PlaywrightAuthenticator(ILogger<PlaywrightAuthenticator> logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<CookieContainer> AuthenticateAsync(
+        string loginUrl,
+        ForumCredentials credentials,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(loginUrl);
+        ArgumentNullException.ThrowIfNull(credentials);
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        _logger.LogInformation(
+            "Starting Playwright authentication for {LoginUrl} as {Username}",
+            loginUrl, credentials.Username);
+
+        _playwright ??= await Playwright.CreateAsync();
+
+        IBrowser? browser = null;
+        try
+        {
+            browser = await _playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+            {
+                Headless = true
+            });
+
+            var context = await browser.NewContextAsync();
+            var page = await context.NewPageAsync();
+
+            page.SetDefaultNavigationTimeout((float)NavigationTimeout.TotalMilliseconds);
+
+            // Navigate to login page
+            _logger.LogDebug("Navigating to {LoginUrl}", loginUrl);
+            var response = await page.GotoAsync(loginUrl, new PageGotoOptions
+            {
+                WaitUntil = WaitUntilState.NetworkIdle
+            });
+
+            if (response is null || !response.Ok)
+            {
+                var status = response?.Status ?? 0;
+                throw new InvalidOperationException(
+                    $"Failed to load login page '{loginUrl}' — HTTP {status}.");
+            }
+
+            // Fill in the login form
+            _logger.LogDebug("Filling login form for user {Username}", credentials.Username);
+
+            await page.FillAsync(UsernameSelector, credentials.Username);
+            await page.FillAsync(PasswordSelector, credentials.Password);
+
+            // Submit the form — reCAPTCHA v3 token is generated automatically by the site's script
+            _logger.LogDebug("Submitting login form (reCAPTCHA v3 will auto-execute)");
+            await page.ClickAsync(SubmitSelector);
+
+            // Wait for navigation after form submission
+            try
+            {
+                await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            }
+            catch (TimeoutException)
+            {
+                _logger.LogWarning("Navigation after login timed out — checking cookies anyway");
+            }
+
+            // Brief wait for any async cookie setting
+            await Task.Delay(PostLoginWait, cancellationToken);
+
+            // Extract cookies
+            var playwrightCookies = await context.CookiesAsync();
+            var cookieContainer = new CookieContainer();
+            var hasSessionCookie = false;
+
+            foreach (var cookie in playwrightCookies)
+            {
+                try
+                {
+                    var netCookie = new System.Net.Cookie(cookie.Name, cookie.Value, cookie.Path, cookie.Domain);
+                    if (cookie.Expires > 0)
+                    {
+                        netCookie.Expires = DateTimeOffset.FromUnixTimeSeconds((long)cookie.Expires).UtcDateTime;
+                    }
+                    netCookie.Secure = cookie.Secure;
+                    netCookie.HttpOnly = cookie.HttpOnly;
+                    cookieContainer.Add(netCookie);
+
+                    if (cookie.Name.Equals(SessionCookieName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        hasSessionCookie = true;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to convert cookie '{CookieName}' — skipping", cookie.Name);
+                }
+            }
+
+            if (!hasSessionCookie)
+            {
+                _logger.LogWarning(
+                    "Session cookie '{SessionCookieName}' not found after login — authentication may have failed. " +
+                    "Cookies found: {CookieNames}",
+                    SessionCookieName,
+                    string.Join(", ", playwrightCookies.Select(c => c.Name)));
+
+                throw new InvalidOperationException(
+                    $"Playwright login completed but session cookie '{SessionCookieName}' was not set. " +
+                    "The login may have failed or the reCAPTCHA challenge was not solved.");
+            }
+
+            _logger.LogInformation(
+                "Playwright authentication succeeded — {CookieCount} cookies extracted (session cookie present)",
+                playwrightCookies.Count);
+
+            return cookieContainer;
+        }
+        finally
+        {
+            if (browser is not null)
+            {
+                await browser.CloseAsync();
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+
+        if (_playwright is not null)
+        {
+            _playwright.Dispose();
+            _playwright = null;
+        }
+
+        await ValueTask.CompletedTask;
+    }
+}

--- a/src/SeriesScraper.Infrastructure/Services/PlaywrightFactory.cs
+++ b/src/SeriesScraper.Infrastructure/Services/PlaywrightFactory.cs
@@ -1,0 +1,11 @@
+using Microsoft.Playwright;
+
+namespace SeriesScraper.Infrastructure.Services;
+
+/// <summary>
+/// Default implementation that creates an IPlaywright instance via the Playwright static factory.
+/// </summary>
+public sealed class PlaywrightFactory : IPlaywrightFactory
+{
+    public Task<IPlaywright> CreateAsync() => Playwright.CreateAsync();
+}

--- a/src/SeriesScraper.Web/Pages/Settings.razor
+++ b/src/SeriesScraper.Web/Pages/Settings.razor
@@ -26,6 +26,11 @@
             Info
         </button>
     </li>
+    <li class="nav-item">
+        <button class="nav-link @(_activeTab == "session" ? "active" : "")" @onclick='() => _activeTab = "session"'>
+            Session Cookies
+        </button>
+    </li>
 </ul>
 
 @if (_loading)
@@ -327,6 +332,52 @@ else
             </div>
         </div>
     }
+
+    @if (_activeTab == "session")
+    {
+        <!-- Manual Session Cookie Injection (#89) -->
+        <div class="card mb-4">
+            <div class="card-header">
+                <h5 class="mb-0">Manual Session Cookie Injection</h5>
+            </div>
+            <div class="card-body">
+                <div class="alert alert-info">
+                    <strong>Fallback for reCAPTCHA-protected forums.</strong>
+                    If Playwright headless login fails, you can manually paste session cookies here.
+                    To get cookie values: log in via your browser, open DevTools (F12) → Application → Cookies,
+                    and copy the cookie string (e.g. <code>warforum_sid=abc123</code>).
+                </div>
+
+                @if (_forums is not null && _forums.Count > 0)
+                {
+                    @foreach (var forum in _forums)
+                    {
+                        <div class="mb-3">
+                            <label class="form-label fw-bold">@forum.Name (ID: @forum.ForumId)</label>
+                            <div class="input-group">
+                                <span class="input-group-text"><code>forum.@(forum.ForumId).session_cookie</code></span>
+                                <input type="text" class="form-control"
+                                       placeholder="warforum_sid=abc123; warforum_data=..."
+                                       value="@GetSessionCookieValue(forum.ForumId)"
+                                       @onchange="(e) => OnSessionCookieChanged(forum.ForumId, e.Value?.ToString())" />
+                            </div>
+                            <small class="text-muted">
+                                Format: <code>name=value; name2=value2</code> — leave empty to use Playwright auto-login.
+                            </small>
+                        </div>
+                    }
+                    <button class="btn btn-primary" @onclick="SaveSessionCookies"
+                            disabled="@(_pendingCookieChanges.Count == 0)">
+                        Save Session Cookies (@_pendingCookieChanges.Count)
+                    </button>
+                }
+                else
+                {
+                    <div class="text-muted">No forums configured. Add a forum first.</div>
+                }
+            </div>
+        </div>
+    }
 }
 
 @code {
@@ -376,6 +427,20 @@ else
             _imdbStatus = await SettingsService.GetImdbImportStatusAsync();
             _appInfo = await AppInfoService.GetAppInfoAsync();
             _dbStats = await AppInfoService.GetDatabaseStatsAsync();
+
+            // Load existing session cookie values for each forum
+            if (_forums is not null && _settings is not null)
+            {
+                foreach (var forum in _forums)
+                {
+                    var key = $"forum.{forum.ForumId}.session_cookie";
+                    var setting = _settings.FirstOrDefault(s => s.Key == key);
+                    if (setting is not null && !string.IsNullOrEmpty(setting.Value))
+                    {
+                        _sessionCookieValues[forum.ForumId] = setting.Value;
+                    }
+                }
+            }
         }
         catch (Exception ex)
         {
@@ -551,5 +616,52 @@ else
         if (uptime.TotalHours >= 1)
             return $"{(int)uptime.TotalHours}h {uptime.Minutes}m";
         return $"{(int)uptime.TotalMinutes}m {uptime.Seconds}s";
+    }
+
+    // ── Session Cookie Injection (#89) ─────────────────────────────────
+
+    private readonly Dictionary<int, string> _pendingCookieChanges = new();
+    private readonly Dictionary<int, string> _sessionCookieValues = new();
+
+    private string GetSessionCookieValue(int forumId)
+    {
+        if (_pendingCookieChanges.TryGetValue(forumId, out var pending))
+            return pending;
+        if (_sessionCookieValues.TryGetValue(forumId, out var current))
+            return current;
+        return "";
+    }
+
+    private void OnSessionCookieChanged(int forumId, string? value)
+    {
+        value ??= "";
+        var original = _sessionCookieValues.GetValueOrDefault(forumId, "");
+        if (value == original)
+            _pendingCookieChanges.Remove(forumId);
+        else
+            _pendingCookieChanges[forumId] = value;
+    }
+
+    private async Task SaveSessionCookies()
+    {
+        _errorMessage = null;
+        _successMessage = null;
+
+        try
+        {
+            foreach (var (forumId, cookieValue) in _pendingCookieChanges)
+            {
+                var key = $"forum.{forumId}.session_cookie";
+                await SettingsService.UpdateSettingAsync(key, cookieValue);
+                _sessionCookieValues[forumId] = cookieValue;
+            }
+
+            _successMessage = $"Saved {_pendingCookieChanges.Count} session cookie(s).";
+            _pendingCookieChanges.Clear();
+        }
+        catch (Exception ex)
+        {
+            _errorMessage = $"Failed to save session cookies: {ex.Message}";
+        }
     }
 }

--- a/src/SeriesScraper.Web/Program.cs
+++ b/src/SeriesScraper.Web/Program.cs
@@ -55,7 +55,16 @@ try
     builder.Services.AddSingleton<IScrapingJobQueue, ScrapingJobQueue>();
 
     // Session management (scoped — one session manager per scope/circuit)
-    builder.Services.AddScoped<IForumSessionManager, ForumSessionManager>();
+    builder.Services.AddScoped<IForumSessionManager>(sp =>
+        new ForumSessionManager(
+            sp.GetRequiredService<IForumScraper>(),
+            sp.GetRequiredService<IForumCredentialService>(),
+            sp.GetRequiredService<ILogger<ForumSessionManager>>(),
+            playwrightAuthenticator: sp.GetService<IPlaywrightAuthenticator>(),
+            settingRepository: sp.GetService<ISettingRepository>()));
+
+    // Playwright authenticator for reCAPTCHA v3 protected forums (#89)
+    builder.Services.AddSingleton<IPlaywrightAuthenticator, PlaywrightAuthenticator>();
 
     // Scoped services
     builder.Services.AddScoped<IScrapeRunService, ScrapeRunService>();

--- a/src/SeriesScraper.Web/Program.cs
+++ b/src/SeriesScraper.Web/Program.cs
@@ -64,6 +64,7 @@ try
             settingRepository: sp.GetService<ISettingRepository>()));
 
     // Playwright authenticator for reCAPTCHA v3 protected forums (#89)
+    builder.Services.AddSingleton<IPlaywrightFactory, PlaywrightFactory>();
     builder.Services.AddSingleton<IPlaywrightAuthenticator, PlaywrightAuthenticator>();
 
     // Scoped services

--- a/tests/SeriesScraper.Application.Tests/Services/ForumSessionManagerTests.cs
+++ b/tests/SeriesScraper.Application.Tests/Services/ForumSessionManagerTests.cs
@@ -562,4 +562,360 @@ public class ForumSessionManagerTests : IDisposable
             Arg.Any<Exception?>(),
             Arg.Any<Func<object, Exception?, string>>());
     }
+
+    // ── Playwright Authentication (#89) ─────────────────────────────
+
+    [Fact]
+    public async Task GetAuthenticatedClientAsync_PlaywrightAvailable_UsesPlaywrightFirst()
+    {
+        var playwrightAuth = Substitute.For<IPlaywrightAuthenticator>();
+        var cookieContainer = new CookieContainer();
+        cookieContainer.Add(new Uri("https://forum.example.com"), new System.Net.Cookie("warforum_sid", "test123"));
+
+        playwrightAuth.AuthenticateAsync(
+            Arg.Any<string>(), Arg.Any<ForumCredentials>(), Arg.Any<CancellationToken>())
+            .Returns(cookieContainer);
+
+        using var sut = new ForumSessionManager(
+            _forumScraper, _credentialService, _logger,
+            playwrightAuthenticator: playwrightAuth);
+
+        var forum = CreateForum();
+        _credentialService.ResolveCredential("FORUM_TEST_PASSWORD").Returns("secret");
+
+        var client = await sut.GetAuthenticatedClientAsync(forum);
+
+        client.Should().NotBeNull();
+        client.BaseAddress.Should().Be(new Uri("https://forum.example.com"));
+
+        // Playwright was called
+        await playwrightAuth.Received(1).AuthenticateAsync(
+            "https://forum.example.com/login.php",
+            Arg.Is<ForumCredentials>(c => c.Username == "testuser" && c.Password == "secret"),
+            Arg.Any<CancellationToken>());
+
+        // IForumScraper was NOT called (Playwright succeeded)
+        await _forumScraper.DidNotReceive().AuthenticateAsync(
+            Arg.Any<ForumCredentials>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetAuthenticatedClientAsync_PlaywrightFails_FallsBackToForumScraper()
+    {
+        var playwrightAuth = Substitute.For<IPlaywrightAuthenticator>();
+        playwrightAuth.AuthenticateAsync(
+            Arg.Any<string>(), Arg.Any<ForumCredentials>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("Playwright browser failed"));
+
+        using var sut = new ForumSessionManager(
+            _forumScraper, _credentialService, _logger,
+            playwrightAuthenticator: playwrightAuth);
+
+        var forum = CreateForum();
+        _credentialService.ResolveCredential("FORUM_TEST_PASSWORD").Returns("secret");
+        _forumScraper.AuthenticateAsync(Arg.Any<ForumCredentials>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var client = await sut.GetAuthenticatedClientAsync(forum);
+
+        client.Should().NotBeNull();
+
+        // Playwright was called first
+        await playwrightAuth.Received(1).AuthenticateAsync(
+            Arg.Any<string>(), Arg.Any<ForumCredentials>(), Arg.Any<CancellationToken>());
+
+        // IForumScraper was called as fallback
+        await _forumScraper.Received(1).AuthenticateAsync(
+            Arg.Any<ForumCredentials>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetAuthenticatedClientAsync_PlaywrightFailsWithCancellation_DoesNotFallBack()
+    {
+        var playwrightAuth = Substitute.For<IPlaywrightAuthenticator>();
+        playwrightAuth.AuthenticateAsync(
+            Arg.Any<string>(), Arg.Any<ForumCredentials>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new OperationCanceledException("Cancelled"));
+
+        using var sut = new ForumSessionManager(
+            _forumScraper, _credentialService, _logger,
+            playwrightAuthenticator: playwrightAuth);
+
+        var forum = CreateForum();
+        _credentialService.ResolveCredential("FORUM_TEST_PASSWORD").Returns("secret");
+
+        var act = () => sut.GetAuthenticatedClientAsync(forum);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+
+        // IForumScraper should NOT be called — cancellation should propagate
+        await _forumScraper.DidNotReceive().AuthenticateAsync(
+            Arg.Any<ForumCredentials>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetAuthenticatedClientAsync_PlaywrightConstructsCorrectLoginUrl()
+    {
+        var playwrightAuth = Substitute.For<IPlaywrightAuthenticator>();
+        playwrightAuth.AuthenticateAsync(
+            Arg.Any<string>(), Arg.Any<ForumCredentials>(), Arg.Any<CancellationToken>())
+            .Returns(new CookieContainer());
+
+        using var sut = new ForumSessionManager(
+            _forumScraper, _credentialService, _logger,
+            playwrightAuthenticator: playwrightAuth);
+
+        var forum = CreateForum();
+        forum.BaseUrl = "https://warforum.xyz/";
+        _credentialService.ResolveCredential("FORUM_TEST_PASSWORD").Returns("secret");
+
+        await sut.GetAuthenticatedClientAsync(forum);
+
+        await playwrightAuth.Received(1).AuthenticateAsync(
+            "https://warforum.xyz/login.php",
+            Arg.Any<ForumCredentials>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetAuthenticatedClientAsync_NoPlaywrightNoManualCookie_UsesForumScraper()
+    {
+        // Default _sut has no Playwright and no SettingRepository
+        var forum = CreateForum();
+        _credentialService.ResolveCredential("FORUM_TEST_PASSWORD").Returns("secret");
+        _forumScraper.AuthenticateAsync(Arg.Any<ForumCredentials>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var client = await _sut.GetAuthenticatedClientAsync(forum);
+
+        client.Should().NotBeNull();
+        await _forumScraper.Received(1).AuthenticateAsync(
+            Arg.Any<ForumCredentials>(), Arg.Any<CancellationToken>());
+    }
+
+    // ── Manual Cookie Injection (#89) ───────────────────────────────
+
+    [Fact]
+    public async Task GetAuthenticatedClientAsync_ManualCookieSet_UsesManualCookie()
+    {
+        var settingRepo = Substitute.For<ISettingRepository>();
+        settingRepo.GetValueAsync("forum.1.session_cookie", Arg.Any<CancellationToken>())
+            .Returns("warforum_sid=manual123; warforum_data=xyz");
+
+        using var sut = new ForumSessionManager(
+            _forumScraper, _credentialService, _logger,
+            settingRepository: settingRepo);
+
+        var forum = CreateForum();
+
+        var client = await sut.GetAuthenticatedClientAsync(forum);
+
+        client.Should().NotBeNull();
+        client.BaseAddress.Should().Be(new Uri("https://forum.example.com"));
+
+        // No Playwright or ForumScraper auth should be called
+        await _forumScraper.DidNotReceive().AuthenticateAsync(
+            Arg.Any<ForumCredentials>(), Arg.Any<CancellationToken>());
+
+        // Credential resolution not needed for manual cookie
+        _credentialService.DidNotReceive().ResolveCredential(Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task GetAuthenticatedClientAsync_ManualCookieEmpty_FallsThrough()
+    {
+        var settingRepo = Substitute.For<ISettingRepository>();
+        settingRepo.GetValueAsync("forum.1.session_cookie", Arg.Any<CancellationToken>())
+            .Returns("");
+
+        using var sut = new ForumSessionManager(
+            _forumScraper, _credentialService, _logger,
+            settingRepository: settingRepo);
+
+        var forum = CreateForum();
+        _credentialService.ResolveCredential("FORUM_TEST_PASSWORD").Returns("secret");
+        _forumScraper.AuthenticateAsync(Arg.Any<ForumCredentials>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var client = await sut.GetAuthenticatedClientAsync(forum);
+
+        client.Should().NotBeNull();
+
+        // Empty manual cookie → falls through to IForumScraper
+        await _forumScraper.Received(1).AuthenticateAsync(
+            Arg.Any<ForumCredentials>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetAuthenticatedClientAsync_ManualCookieNull_FallsThrough()
+    {
+        var settingRepo = Substitute.For<ISettingRepository>();
+        settingRepo.GetValueAsync("forum.1.session_cookie", Arg.Any<CancellationToken>())
+            .Returns((string?)null);
+
+        using var sut = new ForumSessionManager(
+            _forumScraper, _credentialService, _logger,
+            settingRepository: settingRepo);
+
+        var forum = CreateForum();
+        _credentialService.ResolveCredential("FORUM_TEST_PASSWORD").Returns("secret");
+        _forumScraper.AuthenticateAsync(Arg.Any<ForumCredentials>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        await sut.GetAuthenticatedClientAsync(forum);
+
+        await _forumScraper.Received(1).AuthenticateAsync(
+            Arg.Any<ForumCredentials>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetAuthenticatedClientAsync_ManualCookiePrioritizedOverPlaywright()
+    {
+        var playwrightAuth = Substitute.For<IPlaywrightAuthenticator>();
+        var settingRepo = Substitute.For<ISettingRepository>();
+        settingRepo.GetValueAsync("forum.1.session_cookie", Arg.Any<CancellationToken>())
+            .Returns("warforum_sid=fromSettings");
+
+        using var sut = new ForumSessionManager(
+            _forumScraper, _credentialService, _logger,
+            playwrightAuthenticator: playwrightAuth,
+            settingRepository: settingRepo);
+
+        var forum = CreateForum();
+
+        var client = await sut.GetAuthenticatedClientAsync(forum);
+
+        client.Should().NotBeNull();
+
+        // Manual cookie takes priority — neither Playwright nor ForumScraper called
+        await playwrightAuth.DidNotReceive().AuthenticateAsync(
+            Arg.Any<string>(), Arg.Any<ForumCredentials>(), Arg.Any<CancellationToken>());
+        await _forumScraper.DidNotReceive().AuthenticateAsync(
+            Arg.Any<ForumCredentials>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetAuthenticatedClientAsync_ManualCookieUsesCorrectSettingKey()
+    {
+        var settingRepo = Substitute.For<ISettingRepository>();
+        settingRepo.GetValueAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((string?)null);
+
+        using var sut = new ForumSessionManager(
+            _forumScraper, _credentialService, _logger,
+            settingRepository: settingRepo);
+
+        var forum = CreateForum(id: 42);
+        _credentialService.ResolveCredential("FORUM_TEST_PASSWORD").Returns("secret");
+        _forumScraper.AuthenticateAsync(Arg.Any<ForumCredentials>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        await sut.GetAuthenticatedClientAsync(forum);
+
+        // Verify the correct setting key was queried
+        await settingRepo.Received(1).GetValueAsync("forum.42.session_cookie", Arg.Any<CancellationToken>());
+    }
+
+    // ── ManualCookieSettingPrefix/Suffix Constants ──────────────────
+
+    [Fact]
+    public void ManualCookieSettingPrefix_IsCorrect()
+    {
+        ForumSessionManager.ManualCookieSettingPrefix.Should().Be("forum.");
+    }
+
+    [Fact]
+    public void ManualCookieSettingSuffix_IsCorrect()
+    {
+        ForumSessionManager.ManualCookieSettingSuffix.Should().Be(".session_cookie");
+    }
+
+    // ── Full Auth Strategy Chain ────────────────────────────────────
+
+    [Fact]
+    public async Task GetAuthenticatedClientAsync_AllStrategiesFail_ThrowsFromForumScraper()
+    {
+        var playwrightAuth = Substitute.For<IPlaywrightAuthenticator>();
+        playwrightAuth.AuthenticateAsync(
+            Arg.Any<string>(), Arg.Any<ForumCredentials>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("Playwright failed"));
+
+        var settingRepo = Substitute.For<ISettingRepository>();
+        settingRepo.GetValueAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((string?)null);
+
+        using var sut = new ForumSessionManager(
+            _forumScraper, _credentialService, _logger,
+            playwrightAuthenticator: playwrightAuth,
+            settingRepository: settingRepo);
+
+        var forum = CreateForum();
+        _credentialService.ResolveCredential("FORUM_TEST_PASSWORD").Returns("secret");
+        _forumScraper.AuthenticateAsync(Arg.Any<ForumCredentials>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        var act = () => sut.GetAuthenticatedClientAsync(forum);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*Authentication failed*");
+    }
+
+    [Fact]
+    public async Task GetAuthenticatedClientAsync_PlaywrightSucceeds_SessionIsValid()
+    {
+        var playwrightAuth = Substitute.For<IPlaywrightAuthenticator>();
+        playwrightAuth.AuthenticateAsync(
+            Arg.Any<string>(), Arg.Any<ForumCredentials>(), Arg.Any<CancellationToken>())
+            .Returns(new CookieContainer());
+
+        using var sut = new ForumSessionManager(
+            _forumScraper, _credentialService, _logger,
+            playwrightAuthenticator: playwrightAuth);
+
+        var forum = CreateForum();
+        _credentialService.ResolveCredential("FORUM_TEST_PASSWORD").Returns("secret");
+
+        await sut.GetAuthenticatedClientAsync(forum);
+
+        sut.IsSessionValid(forum.ForumId).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetAuthenticatedClientAsync_ManualCookie_SessionIsValid()
+    {
+        var settingRepo = Substitute.For<ISettingRepository>();
+        settingRepo.GetValueAsync("forum.1.session_cookie", Arg.Any<CancellationToken>())
+            .Returns("warforum_sid=test");
+
+        using var sut = new ForumSessionManager(
+            _forumScraper, _credentialService, _logger,
+            settingRepository: settingRepo);
+
+        var forum = CreateForum();
+
+        await sut.GetAuthenticatedClientAsync(forum);
+
+        sut.IsSessionValid(forum.ForumId).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetAuthenticatedClientAsync_ManualCookieReusesSession()
+    {
+        var settingRepo = Substitute.For<ISettingRepository>();
+        settingRepo.GetValueAsync("forum.1.session_cookie", Arg.Any<CancellationToken>())
+            .Returns("warforum_sid=test");
+
+        using var sut = new ForumSessionManager(
+            _forumScraper, _credentialService, _logger,
+            settingRepository: settingRepo);
+
+        var forum = CreateForum();
+
+        var client1 = await sut.GetAuthenticatedClientAsync(forum);
+        var client2 = await sut.GetAuthenticatedClientAsync(forum);
+
+        client1.Should().BeSameAs(client2);
+
+        // Setting repo only queried once (for the initial auth, not for reuse)
+        await settingRepo.Received(1).GetValueAsync("forum.1.session_cookie", Arg.Any<CancellationToken>());
+    }
 }

--- a/tests/SeriesScraper.Application.Tests/Services/ForumSessionManagerTests.cs
+++ b/tests/SeriesScraper.Application.Tests/Services/ForumSessionManagerTests.cs
@@ -922,10 +922,11 @@ public class ForumSessionManagerTests : IDisposable
     [Fact]
     public async Task GetAuthenticatedClientAsync_InvalidCookieNameWithSpace_LogsWarningAndDoesNotThrow()
     {
-        // Arrange — a cookie name with a space is illegal (CookieException)
+        // Arrange — a cookie name starting with '$' is illegal per RFC 6265 and throws CookieException.
+        // Note: .NET 8 allows spaces in cookie names but still rejects '$'-prefixed names.
         var settingRepo = Substitute.For<ISettingRepository>();
         settingRepo.GetValueAsync("forum.1.session_cookie", Arg.Any<CancellationToken>())
-            .Returns("bad name with space=value");
+            .Returns("$invalid_cookie=value");
 
         using var sut = new ForumSessionManager(
             _forumScraper, _credentialService, _logger,

--- a/tests/SeriesScraper.Application.Tests/Services/ForumSessionManagerTests.cs
+++ b/tests/SeriesScraper.Application.Tests/Services/ForumSessionManagerTests.cs
@@ -949,5 +949,9 @@ public class ForumSessionManagerTests : IDisposable
                              || o.ToString()!.Contains("Skipping", StringComparison.OrdinalIgnoreCase)),
             Arg.Any<CookieException?>(),
             Arg.Any<Func<object, Exception?, string>>());
+
+        // Assert — all cookies were malformed so auth fell through to IForumScraper
+        await _forumScraper.Received(1).AuthenticateAsync(
+            Arg.Any<ForumCredentials>(), Arg.Any<CancellationToken>());
     }
 }

--- a/tests/SeriesScraper.Application.Tests/Services/ForumSessionManagerTests.cs
+++ b/tests/SeriesScraper.Application.Tests/Services/ForumSessionManagerTests.cs
@@ -918,4 +918,35 @@ public class ForumSessionManagerTests : IDisposable
         // Setting repo only queried once (for the initial auth, not for reuse)
         await settingRepo.Received(1).GetValueAsync("forum.1.session_cookie", Arg.Any<CancellationToken>());
     }
+
+    [Fact]
+    public async Task GetAuthenticatedClientAsync_InvalidCookieNameWithSpace_LogsWarningAndDoesNotThrow()
+    {
+        // Arrange — a cookie name with a space is illegal (CookieException)
+        var settingRepo = Substitute.For<ISettingRepository>();
+        settingRepo.GetValueAsync("forum.1.session_cookie", Arg.Any<CancellationToken>())
+            .Returns("bad name with space=value");
+
+        using var sut = new ForumSessionManager(
+            _forumScraper, _credentialService, _logger,
+            settingRepository: settingRepo);
+
+        var forum = CreateForum();
+        _credentialService.ResolveCredential("FORUM_TEST_PASSWORD").Returns("secret");
+        _forumScraper.AuthenticateAsync(Arg.Any<ForumCredentials>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        // Act — must not propagate CookieException
+        var act = () => sut.GetAuthenticatedClientAsync(forum);
+        await act.Should().NotThrowAsync();
+
+        // Assert — a warning was logged about the skipped invalid cookie
+        _logger.Received().Log(
+            LogLevel.Warning,
+            Arg.Any<EventId>(),
+            Arg.Is<object>(o => o.ToString()!.Contains("invalid", StringComparison.OrdinalIgnoreCase)
+                             || o.ToString()!.Contains("Skipping", StringComparison.OrdinalIgnoreCase)),
+            Arg.Any<CookieException?>(),
+            Arg.Any<Func<object, Exception?, string>>());
+    }
 }

--- a/tests/SeriesScraper.Infrastructure.Tests/Services/PlaywrightAuthenticatorTests.cs
+++ b/tests/SeriesScraper.Infrastructure.Tests/Services/PlaywrightAuthenticatorTests.cs
@@ -1,0 +1,132 @@
+using System.Net;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using SeriesScraper.Domain.ValueObjects;
+using SeriesScraper.Infrastructure.Services;
+
+namespace SeriesScraper.Infrastructure.Tests.Services;
+
+public class PlaywrightAuthenticatorTests : IAsyncDisposable
+{
+    private readonly ILogger<PlaywrightAuthenticator> _logger = Substitute.For<ILogger<PlaywrightAuthenticator>>();
+
+    public async ValueTask DisposeAsync()
+    {
+        // No resources to clean up in unit tests with mocked Playwright
+        await ValueTask.CompletedTask;
+    }
+
+    // ── Constructor Validation ─────────────────────────────────────
+
+    [Fact]
+    public void Constructor_NullLogger_ThrowsArgumentNullException()
+    {
+        var act = () => new PlaywrightAuthenticator(null!);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("logger");
+    }
+
+    [Fact]
+    public void Constructor_ValidLogger_DoesNotThrow()
+    {
+        var act = () => new PlaywrightAuthenticator(_logger);
+        act.Should().NotThrow();
+    }
+
+    // ── AuthenticateAsync Input Validation ──────────────────────────
+
+    [Fact]
+    public async Task AuthenticateAsync_NullLoginUrl_ThrowsArgumentException()
+    {
+        var sut = new PlaywrightAuthenticator(_logger);
+        var credentials = new ForumCredentials { Username = "user", Password = "pass" };
+
+        var act = () => sut.AuthenticateAsync(null!, credentials);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_EmptyLoginUrl_ThrowsArgumentException()
+    {
+        var sut = new PlaywrightAuthenticator(_logger);
+        var credentials = new ForumCredentials { Username = "user", Password = "pass" };
+
+        var act = () => sut.AuthenticateAsync("", credentials);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_WhitespaceLoginUrl_ThrowsArgumentException()
+    {
+        var sut = new PlaywrightAuthenticator(_logger);
+        var credentials = new ForumCredentials { Username = "user", Password = "pass" };
+
+        var act = () => sut.AuthenticateAsync("   ", credentials);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_NullCredentials_ThrowsArgumentNullException()
+    {
+        var sut = new PlaywrightAuthenticator(_logger);
+
+        var act = () => sut.AuthenticateAsync("https://forum.example.com/login.php", null!);
+
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_AfterDispose_ThrowsObjectDisposedException()
+    {
+        var sut = new PlaywrightAuthenticator(_logger);
+        await sut.DisposeAsync();
+
+        var credentials = new ForumCredentials { Username = "user", Password = "pass" };
+        var act = () => sut.AuthenticateAsync("https://forum.example.com/login.php", credentials);
+
+        await act.Should().ThrowAsync<ObjectDisposedException>();
+    }
+
+    // ── Constants Verification ──────────────────────────────────────
+
+    [Fact]
+    public void UsernameSelector_IsCorrectCssSelector()
+    {
+        PlaywrightAuthenticator.UsernameSelector.Should().Be("input[name='username']");
+    }
+
+    [Fact]
+    public void PasswordSelector_IsCorrectCssSelector()
+    {
+        PlaywrightAuthenticator.PasswordSelector.Should().Be("input[name='password']");
+    }
+
+    [Fact]
+    public void SubmitSelector_IsCorrectCssSelector()
+    {
+        PlaywrightAuthenticator.SubmitSelector.Should().Be("input[name='login'], input[type='submit']");
+    }
+
+    [Fact]
+    public void SessionCookieName_IsWarforumSid()
+    {
+        PlaywrightAuthenticator.SessionCookieName.Should().Be("warforum_sid");
+    }
+
+    // ── Dispose ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DisposeAsync_CalledTwice_DoesNotThrow()
+    {
+        var sut = new PlaywrightAuthenticator(_logger);
+        await sut.DisposeAsync();
+
+        var act = async () => await sut.DisposeAsync();
+        await act.Should().NotThrowAsync();
+    }
+}

--- a/tests/SeriesScraper.Infrastructure.Tests/Services/PlaywrightAuthenticatorTests.cs
+++ b/tests/SeriesScraper.Infrastructure.Tests/Services/PlaywrightAuthenticatorTests.cs
@@ -11,27 +11,66 @@ namespace SeriesScraper.Infrastructure.Tests.Services;
 
 public class PlaywrightAuthenticatorTests : IAsyncDisposable
 {
-    private readonly ILogger<PlaywrightAuthenticator> _logger = Substitute.For<ILogger<PlaywrightAuthenticator>>();
+    private readonly ILogger<PlaywrightAuthenticator> _logger =
+        Substitute.For<ILogger<PlaywrightAuthenticator>>();
+
+    private readonly IPlaywrightFactory _factory =
+        Substitute.For<IPlaywrightFactory>();
+
+    // Playwright browser mock chain used by auth-flow tests
+    private readonly IPlaywright _playwright = Substitute.For<IPlaywright>();
+    private readonly IBrowserType _browserType = Substitute.For<IBrowserType>();
+    private readonly IBrowser _browser = Substitute.For<IBrowser>();
+    private readonly IBrowserContext _context = Substitute.For<IBrowserContext>();
+    private readonly IPage _page = Substitute.For<IPage>();
+    private readonly IResponse _response = Substitute.For<IResponse>();
+
+    public PlaywrightAuthenticatorTests()
+    {
+        // Wire up the happy-path mock chain (individual tests override what they need)
+        _factory.CreateAsync().Returns(_playwright);
+        _playwright.Chromium.Returns(_browserType);
+        _browserType.LaunchAsync(Arg.Any<BrowserTypeLaunchOptions>()).Returns(_browser);
+        _browser.NewContextAsync(Arg.Any<BrowserNewContextOptions?>()).Returns(_context);
+        _context.NewPageAsync().Returns(_page);
+        _response.Ok.Returns(true);
+        _response.Status.Returns(200);
+        _page.GotoAsync(Arg.Any<string>(), Arg.Any<PageGotoOptions?>()).Returns(_response);
+        _page.FillAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<PageFillOptions?>()).Returns(Task.CompletedTask);
+        _page.ClickAsync(Arg.Any<string>(), Arg.Any<PageClickOptions?>()).Returns(Task.CompletedTask);
+        _page.WaitForLoadStateAsync(Arg.Any<LoadState?>(), Arg.Any<PageWaitForLoadStateOptions?>()).Returns(Task.CompletedTask);
+        _browser.CloseAsync().Returns(Task.CompletedTask);
+    }
 
     public async ValueTask DisposeAsync()
     {
-        // No resources to clean up in unit tests with mocked Playwright
         await ValueTask.CompletedTask;
     }
+
+    /// Creates a sut with TimeSpan.Zero post-login wait so auth tests run instantly.
+    private PlaywrightAuthenticator CreateSut() =>
+        new(_logger, _factory, TimeSpan.Zero);
 
     // ── Constructor Validation ─────────────────────────────────────
 
     [Fact]
     public void Constructor_NullLogger_ThrowsArgumentNullException()
     {
-        var act = () => new PlaywrightAuthenticator(null!);
+        var act = () => new PlaywrightAuthenticator(null!, _factory);
         act.Should().Throw<ArgumentNullException>().WithParameterName("logger");
     }
 
     [Fact]
-    public void Constructor_ValidLogger_DoesNotThrow()
+    public void Constructor_NullFactory_ThrowsArgumentNullException()
     {
-        var act = () => new PlaywrightAuthenticator(_logger);
+        var act = () => new PlaywrightAuthenticator(_logger, null!);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("playwrightFactory");
+    }
+
+    [Fact]
+    public void Constructor_ValidArguments_DoesNotThrow()
+    {
+        var act = () => new PlaywrightAuthenticator(_logger, _factory);
         act.Should().NotThrow();
     }
 
@@ -40,7 +79,7 @@ public class PlaywrightAuthenticatorTests : IAsyncDisposable
     [Fact]
     public async Task AuthenticateAsync_NullLoginUrl_ThrowsArgumentException()
     {
-        var sut = new PlaywrightAuthenticator(_logger);
+        var sut = CreateSut();
         var credentials = new ForumCredentials { Username = "user", Password = "pass" };
 
         var act = () => sut.AuthenticateAsync(null!, credentials);
@@ -51,7 +90,7 @@ public class PlaywrightAuthenticatorTests : IAsyncDisposable
     [Fact]
     public async Task AuthenticateAsync_EmptyLoginUrl_ThrowsArgumentException()
     {
-        var sut = new PlaywrightAuthenticator(_logger);
+        var sut = CreateSut();
         var credentials = new ForumCredentials { Username = "user", Password = "pass" };
 
         var act = () => sut.AuthenticateAsync("", credentials);
@@ -62,7 +101,7 @@ public class PlaywrightAuthenticatorTests : IAsyncDisposable
     [Fact]
     public async Task AuthenticateAsync_WhitespaceLoginUrl_ThrowsArgumentException()
     {
-        var sut = new PlaywrightAuthenticator(_logger);
+        var sut = CreateSut();
         var credentials = new ForumCredentials { Username = "user", Password = "pass" };
 
         var act = () => sut.AuthenticateAsync("   ", credentials);
@@ -73,7 +112,7 @@ public class PlaywrightAuthenticatorTests : IAsyncDisposable
     [Fact]
     public async Task AuthenticateAsync_NullCredentials_ThrowsArgumentNullException()
     {
-        var sut = new PlaywrightAuthenticator(_logger);
+        var sut = CreateSut();
 
         var act = () => sut.AuthenticateAsync("https://forum.example.com/login.php", null!);
 
@@ -83,13 +122,169 @@ public class PlaywrightAuthenticatorTests : IAsyncDisposable
     [Fact]
     public async Task AuthenticateAsync_AfterDispose_ThrowsObjectDisposedException()
     {
-        var sut = new PlaywrightAuthenticator(_logger);
+        var sut = CreateSut();
         await sut.DisposeAsync();
 
         var credentials = new ForumCredentials { Username = "user", Password = "pass" };
         var act = () => sut.AuthenticateAsync("https://forum.example.com/login.php", credentials);
 
         await act.Should().ThrowAsync<ObjectDisposedException>();
+    }
+
+    // ── Auth Flow — Successful Login ────────────────────────────────
+
+    [Fact]
+    public async Task AuthenticateAsync_SuccessfulLogin_ReturnsCookiesWithSessionCookie()
+    {
+        // Arrange
+        var sessionCookie = new BrowserContextCookiesResult
+        {
+            Name = "warforum_sid",
+            Value = "abc123session",
+            Path = "/",
+            Domain = "forum.example.com",
+            Secure = false,
+            HttpOnly = true,
+            Expires = -1
+        };
+
+        _context.CookiesAsync()
+            .Returns(new List<BrowserContextCookiesResult> { sessionCookie });
+
+        var sut = CreateSut();
+        var credentials = new ForumCredentials { Username = "user", Password = "pass" };
+
+        // Act
+        var result = await sut.AuthenticateAsync("https://forum.example.com/login.php", credentials);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.GetCookies(new Uri("https://forum.example.com/")).Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_SuccessfulLogin_DisposesPlaywrightAndBrowserAfterCall()
+    {
+        // Arrange
+        _context.CookiesAsync()
+            .Returns(new List<BrowserContextCookiesResult>
+            {
+                new() { Name = "warforum_sid", Value = "s", Path = "/", Domain = "forum.example.com" }
+            });
+
+        var sut = CreateSut();
+        var credentials = new ForumCredentials { Username = "user", Password = "pass" };
+
+        // Act
+        await sut.AuthenticateAsync("https://forum.example.com/login.php", credentials);
+
+        // Assert — per-call playwright must be disposed and browser closed
+        _playwright.Received(1).Dispose();
+        await _browser.Received(1).CloseAsync();
+    }
+
+    // ── Auth Flow — Login Page Fails to Load ───────────────────────
+
+    [Fact]
+    public async Task AuthenticateAsync_LoginPageReturnsHttpError_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        _response.Ok.Returns(false);
+        _response.Status.Returns(403);
+
+        var sut = CreateSut();
+        var credentials = new ForumCredentials { Username = "user", Password = "pass" };
+
+        var act = () => sut.AuthenticateAsync("https://forum.example.com/login.php", credentials);
+
+        // Act & Assert
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*Failed to load login page*");
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_LoginPageReturnsNullResponse_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        _page.GotoAsync(Arg.Any<string>(), Arg.Any<PageGotoOptions?>())
+            .Returns((IResponse?)null);
+
+        var sut = CreateSut();
+        var credentials = new ForumCredentials { Username = "user", Password = "pass" };
+
+        var act = () => sut.AuthenticateAsync("https://forum.example.com/login.php", credentials);
+
+        // Act & Assert
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*Failed to load login page*");
+    }
+
+    // ── Auth Flow — No Session Cookie After Login ──────────────────
+
+    [Fact]
+    public async Task AuthenticateAsync_NoSessionCookieAfterLogin_ThrowsInvalidOperationException()
+    {
+        // Arrange — cookies returned but warforum_sid is absent
+        _context.CookiesAsync()
+            .Returns(new List<BrowserContextCookiesResult>
+            {
+                new() { Name = "phpbb_data", Value = "x", Path = "/", Domain = "forum.example.com" }
+            });
+
+        var sut = CreateSut();
+        var credentials = new ForumCredentials { Username = "user", Password = "pass" };
+
+        var act = () => sut.AuthenticateAsync("https://forum.example.com/login.php", credentials);
+
+        // Act & Assert
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*session cookie*");
+    }
+
+    // ── Auth Flow — Browser Launch Failure ────────────────────────
+
+    [Fact]
+    public async Task AuthenticateAsync_BrowserLaunchThrows_PropagatesExceptionAndDisposesPlaywright()
+    {
+        // Arrange
+        var launchError = new InvalidOperationException("Browser binary not found");
+        _browserType.LaunchAsync(Arg.Any<BrowserTypeLaunchOptions>())
+            .ThrowsAsync(launchError);
+
+        var sut = CreateSut();
+        var credentials = new ForumCredentials { Username = "user", Password = "pass" };
+
+        var act = () => sut.AuthenticateAsync("https://forum.example.com/login.php", credentials);
+
+        // Act & Assert — exception propagates; playwright is still disposed in finally
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Browser binary not found");
+        _playwright.Received(1).Dispose();
+    }
+
+    // ── Auth Flow — Cookie with Illegal Name Characters ────────────
+
+    [Fact]
+    public async Task AuthenticateAsync_CookieWithIllegalName_IsSkippedAndSessionCookieStillExtracted()
+    {
+        // Arrange — first cookie has CR/LF in name (illegal), second is the valid session cookie
+        _context.CookiesAsync()
+            .Returns(new List<BrowserContextCookiesResult>
+            {
+                new() { Name = "bad\r\ncookie", Value = "x", Path = "/", Domain = "forum.example.com" },
+                new() { Name = "warforum_sid", Value = "good123", Path = "/", Domain = "forum.example.com" }
+            });
+
+        var sut = CreateSut();
+        var credentials = new ForumCredentials { Username = "user", Password = "pass" };
+
+        // Act — should not throw; bad cookie is silently skipped
+        var result = await sut.AuthenticateAsync("https://forum.example.com/login.php", credentials);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.GetCookies(new Uri("https://forum.example.com/"))
+            .Should().Contain(c => c.Name == "warforum_sid");
     }
 
     // ── Constants Verification ──────────────────────────────────────
@@ -123,7 +318,7 @@ public class PlaywrightAuthenticatorTests : IAsyncDisposable
     [Fact]
     public async Task DisposeAsync_CalledTwice_DoesNotThrow()
     {
-        var sut = new PlaywrightAuthenticator(_logger);
+        var sut = CreateSut();
         await sut.DisposeAsync();
 
         var act = async () => await sut.DisposeAsync();


### PR DESCRIPTION
Closes #89

## Summary
Implements Playwright headless browser authentication as primary auth method for reCAPTCHA v3 protected forums, with manual cookie injection as fallback.

## Changes

### New Files
- **src/SeriesScraper.Domain/Interfaces/IPlaywrightAuthenticator.cs** — Domain interface for headless browser authentication
- **src/SeriesScraper.Infrastructure/Services/PlaywrightAuthenticator.cs** — Playwright Chromium implementation: launches headless browser, navigates to login page, fills credentials, submits form (reCAPTCHA v3 auto-executes), extracts session cookies
- **tests/SeriesScraper.Infrastructure.Tests/Services/PlaywrightAuthenticatorTests.cs** — 12 unit tests

### Modified Files
- **src/SeriesScraper.Application/Services/ForumSessionManager.cs** — 3-strategy authentication chain:
  1. Manual cookie injection (setting key \orum.{id}.session_cookie\)
  2. Playwright headless browser (handles reCAPTCHA v3)
  3. IForumScraper.AuthenticateAsync fallback
- **src/SeriesScraper.Web/Pages/Settings.razor** — New 'Session Cookies' tab for manual cookie injection per forum
- **src/SeriesScraper.Web/Program.cs** — Register PlaywrightAuthenticator singleton + factory for ForumSessionManager DI
- **src/SeriesScraper.Infrastructure/SeriesScraper.Infrastructure.csproj** — Added Microsoft.Playwright 1.52.0
- **Dockerfile** — Switched from Alpine to Debian base for Playwright Chromium deps, installs browser at build time
- **tests/SeriesScraper.Application.Tests/Services/ForumSessionManagerTests.cs** — 15 new tests for Playwright + manual cookie paths

## Testing
- 27 new tests added (12 PlaywrightAuthenticator + 15 ForumSessionManager)
- All 538 tests pass
- Playwright is mocked in unit tests (no actual browser required)

## Known Limitations
- reCAPTCHA v3 scoring is site-dependent; headless Chromium may receive lower trust scores than a real browser. Manual cookie injection serves as fallback when this happens.
- Dockerfile is now Debian-based (not Alpine) to support Playwright browser dependencies.