### PR TITLE
feat(#99): Implement PhpBB2ForumScraper — concrete IForumScraper for phpBB2 forums

### DIFF
--- a/src/SeriesScraper.Application/Services/ForumSessionManager.cs
+++ b/src/SeriesScraper.Application/Services/ForumSessionManager.cs
@@ -187,7 +187,8 @@ public sealed class ForumSessionManager : IForumSessionManager
         var credentials = new ForumCredentials
         {
             Username = forum.Username,
-            Password = password
+            Password = password,
+            BaseUrl = forum.BaseUrl
         };
 
         // Strategy 2: Playwright headless browser (handles reCAPTCHA v3)

--- a/src/SeriesScraper.Domain/ValueObjects/ForumCredentials.cs
+++ b/src/SeriesScraper.Domain/ValueObjects/ForumCredentials.cs
@@ -14,4 +14,10 @@ public sealed record ForumCredentials
     /// The forum password.
     /// </summary>
     public required string Password { get; init; }
+
+    /// <summary>
+    /// The forum base URL (e.g., "https://forum.example.com").
+    /// Used by IForumScraper implementations to know where to authenticate.
+    /// </summary>
+    public string? BaseUrl { get; init; }
 }

--- a/src/SeriesScraper.Infrastructure/Services/Scrapers/PhpBB2ForumScraper.cs
+++ b/src/SeriesScraper.Infrastructure/Services/Scrapers/PhpBB2ForumScraper.cs
@@ -1,0 +1,446 @@
+using System.Net;
+using System.Runtime.CompilerServices;
+using HtmlAgilityPack;
+using Microsoft.Extensions.Logging;
+using SeriesScraper.Domain.Exceptions;
+using SeriesScraper.Domain.Interfaces;
+using SeriesScraper.Domain.ValueObjects;
+
+namespace SeriesScraper.Infrastructure.Services.Scrapers;
+
+/// <summary>
+/// Concrete IForumScraper implementation for phpBB2-based forums.
+/// Handles authentication, section/thread enumeration, post extraction,
+/// and link extraction against phpBB2 HTML structures.
+/// </summary>
+public sealed class PhpBB2ForumScraper : IForumScraper, IDisposable
+{
+    private readonly IHtmlForumSectionParser _sectionParser;
+    private readonly IResponseValidator _responseValidator;
+    private readonly ILogger<PhpBB2ForumScraper> _logger;
+
+    private readonly CookieContainer _cookieContainer;
+    private readonly HttpClient _httpClient;
+    private readonly bool _ownsHttpClient;
+    private string? _authenticatedBaseUrl;
+
+    public PhpBB2ForumScraper(
+        IHtmlForumSectionParser sectionParser,
+        IResponseValidator responseValidator,
+        ILogger<PhpBB2ForumScraper> logger)
+    {
+        _sectionParser = sectionParser ?? throw new ArgumentNullException(nameof(sectionParser));
+        _responseValidator = responseValidator ?? throw new ArgumentNullException(nameof(responseValidator));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+        _cookieContainer = new CookieContainer();
+        var handler = new HttpClientHandler
+        {
+            CookieContainer = _cookieContainer,
+            UseCookies = true,
+            AllowAutoRedirect = true
+        };
+        _httpClient = new HttpClient(handler);
+        _ownsHttpClient = true;
+    }
+
+    /// <summary>
+    /// Internal constructor for unit testing — allows injecting a custom HttpClient.
+    /// </summary>
+    internal PhpBB2ForumScraper(
+        IHtmlForumSectionParser sectionParser,
+        IResponseValidator responseValidator,
+        ILogger<PhpBB2ForumScraper> logger,
+        HttpClient httpClient,
+        CookieContainer cookieContainer)
+    {
+        _sectionParser = sectionParser ?? throw new ArgumentNullException(nameof(sectionParser));
+        _responseValidator = responseValidator ?? throw new ArgumentNullException(nameof(responseValidator));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _cookieContainer = cookieContainer ?? throw new ArgumentNullException(nameof(cookieContainer));
+        _ownsHttpClient = false;
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> AuthenticateAsync(ForumCredentials credentials, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(credentials);
+
+        if (string.IsNullOrWhiteSpace(credentials.BaseUrl))
+            throw new ScrapingException("BaseUrl must be set on ForumCredentials for phpBB2 authentication.");
+
+        var baseUrl = credentials.BaseUrl.TrimEnd('/');
+        var loginUrl = $"{baseUrl}/login.php";
+
+        _logger.LogDebug("Authenticating to phpBB2 forum at {LoginUrl} as {Username}", loginUrl, credentials.Username);
+
+        try
+        {
+            var formData = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["username"] = credentials.Username,
+                ["password"] = credentials.Password,
+                ["login"] = "Log in",
+                ["autologin"] = "on"
+            });
+
+            var response = await _httpClient.PostAsync(loginUrl, formData, cancellationToken);
+            response.EnsureSuccessStatusCode();
+
+            var html = await response.Content.ReadAsStringAsync(cancellationToken);
+
+            // If the response is still a login page, authentication failed
+            if (_responseValidator.IsSessionExpired(html))
+            {
+                _logger.LogWarning("Authentication failed for phpBB2 forum at {BaseUrl} — login page returned", baseUrl);
+                return false;
+            }
+
+            _authenticatedBaseUrl = baseUrl;
+            _logger.LogInformation("Successfully authenticated to phpBB2 forum at {BaseUrl}", baseUrl);
+            return true;
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogError(ex, "HTTP error during phpBB2 authentication at {LoginUrl}", loginUrl);
+            throw new ScrapingException($"Network error during authentication to {loginUrl}", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public CookieContainer GetCookieContainer() => _cookieContainer;
+
+    /// <inheritdoc />
+    public async Task<bool> ValidateSessionAsync(CancellationToken cancellationToken = default)
+    {
+        if (_authenticatedBaseUrl is null)
+            return false;
+
+        try
+        {
+            var indexUrl = $"{_authenticatedBaseUrl}/index.php";
+            var html = await _httpClient.GetStringAsync(indexUrl, cancellationToken);
+            return !_responseValidator.IsSessionExpired(html);
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(ex, "Failed to validate session for phpBB2 forum at {BaseUrl}", _authenticatedBaseUrl);
+            return false;
+        }
+    }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<ForumSection> EnumerateSectionsAsync(
+        string baseUrl,
+        int depth = 1,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(baseUrl);
+        if (depth < 1) throw new ArgumentOutOfRangeException(nameof(depth), "Depth must be at least 1.");
+
+        var normalizedBase = baseUrl.TrimEnd('/');
+
+        _logger.LogDebug("Enumerating phpBB2 sections at {BaseUrl} with depth {Depth}", normalizedBase, depth);
+
+        string html;
+        try
+        {
+            var indexUrl = $"{normalizedBase}/index.php";
+            html = await _httpClient.GetStringAsync(indexUrl, cancellationToken);
+        }
+        catch (HttpRequestException ex)
+        {
+            throw new ScrapingException($"Failed to fetch forum index at {normalizedBase}", ex);
+        }
+
+        var sections = _sectionParser.ParseSections(html, normalizedBase);
+
+        foreach (var section in sections)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return section;
+
+            // Recurse for deeper levels
+            if (depth > 1)
+            {
+                await foreach (var subSection in EnumerateSubSectionsAsync(
+                    section.Url, normalizedBase, depth - 1, 2, cancellationToken))
+                {
+                    yield return subSection;
+                }
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<ForumThread> EnumerateThreadsAsync(
+        string sectionUrl,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(sectionUrl);
+
+        _logger.LogDebug("Enumerating threads in phpBB2 section {SectionUrl}", sectionUrl);
+
+        var currentUrl = sectionUrl;
+
+        while (currentUrl is not null)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            string html;
+            try
+            {
+                html = await _httpClient.GetStringAsync(currentUrl, cancellationToken);
+            }
+            catch (HttpRequestException ex)
+            {
+                throw new ScrapingException($"Failed to fetch section page at {currentUrl}", ex);
+            }
+
+            var doc = new HtmlDocument();
+            doc.LoadHtml(html);
+
+            var threads = ParseThreadsFromHtml(doc, sectionUrl);
+            foreach (var thread in threads)
+            {
+                yield return thread;
+            }
+
+            // Check for next page
+            currentUrl = FindNextPageUrl(doc, sectionUrl);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<PostContent>> ExtractPostContentAsync(
+        string threadUrl,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(threadUrl);
+
+        _logger.LogDebug("Extracting post content from phpBB2 thread {ThreadUrl}", threadUrl);
+
+        string html;
+        try
+        {
+            html = await _httpClient.GetStringAsync(threadUrl, cancellationToken);
+        }
+        catch (HttpRequestException ex)
+        {
+            throw new ScrapingException($"Failed to fetch thread at {threadUrl}", ex);
+        }
+
+        var doc = new HtmlDocument();
+        doc.LoadHtml(html);
+
+        return ParsePostsFromHtml(doc, threadUrl);
+    }
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<ExtractedLink>> ExtractLinksAsync(
+        PostContent postContent,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(postContent);
+
+        var doc = new HtmlDocument();
+        doc.LoadHtml(postContent.HtmlContent);
+
+        var links = new List<ExtractedLink>();
+
+        var anchorNodes = doc.DocumentNode.SelectNodes("//a[@href]");
+        if (anchorNodes is not null)
+        {
+            foreach (var anchor in anchorNodes)
+            {
+                var href = HtmlEntity.DeEntitize(anchor.GetAttributeValue("href", "")).Trim();
+                if (string.IsNullOrWhiteSpace(href))
+                    continue;
+
+                // Skip internal forum links and anchors
+                if (href.StartsWith('#') ||
+                    href.Contains("viewtopic.php", StringComparison.OrdinalIgnoreCase) ||
+                    href.Contains("viewforum.php", StringComparison.OrdinalIgnoreCase) ||
+                    href.Contains("login.php", StringComparison.OrdinalIgnoreCase) ||
+                    href.Contains("profile.php", StringComparison.OrdinalIgnoreCase) ||
+                    href.Contains("posting.php", StringComparison.OrdinalIgnoreCase) ||
+                    href.Contains("memberlist.php", StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                if (!Uri.TryCreate(href, UriKind.Absolute, out var uri))
+                    continue;
+
+                var linkText = HtmlEntity.DeEntitize(anchor.InnerText).Trim();
+
+                links.Add(new ExtractedLink
+                {
+                    Url = uri.AbsoluteUri,
+                    Scheme = uri.Scheme,
+                    LinkText = string.IsNullOrWhiteSpace(linkText) ? null : linkText
+                });
+            }
+        }
+
+        return Task.FromResult<IReadOnlyList<ExtractedLink>>(links.AsReadOnly());
+    }
+
+    public void Dispose()
+    {
+        if (_ownsHttpClient)
+        {
+            _httpClient.Dispose();
+        }
+    }
+
+    // --- Private helpers ---
+
+    private async IAsyncEnumerable<ForumSection> EnumerateSubSectionsAsync(
+        string sectionUrl,
+        string baseUrl,
+        int remainingDepth,
+        int currentDepth,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        string html;
+        try
+        {
+            html = await _httpClient.GetStringAsync(sectionUrl, cancellationToken);
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(ex, "Failed to fetch sub-section at {SectionUrl}, skipping", sectionUrl);
+            yield break;
+        }
+
+        var subSections = _sectionParser.ParseSections(html, baseUrl);
+
+        foreach (var sub in subSections)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // Adjust depth for the sub-section
+            var adjusted = sub with { Depth = currentDepth, ParentUrl = sectionUrl };
+            yield return adjusted;
+
+            if (remainingDepth > 1)
+            {
+                await foreach (var deeper in EnumerateSubSectionsAsync(
+                    adjusted.Url, baseUrl, remainingDepth - 1, currentDepth + 1, cancellationToken))
+                {
+                    yield return deeper;
+                }
+            }
+        }
+    }
+
+    internal static IReadOnlyList<ForumThread> ParseThreadsFromHtml(HtmlDocument doc, string sectionUrl)
+    {
+        var threads = new List<ForumThread>();
+
+        // phpBB2: threads are links with class 'topictitle' pointing to viewtopic.php
+        var topicNodes = doc.DocumentNode.SelectNodes(
+            "//a[contains(@class, 'topictitle') and contains(@href, 'viewtopic.php')]");
+
+        if (topicNodes is null)
+        {
+            // Fallback: any viewtopic.php link inside topic row areas
+            topicNodes = doc.DocumentNode.SelectNodes(
+                "//td[contains(@class, 'row')]//a[contains(@href, 'viewtopic.php')]");
+        }
+
+        if (topicNodes is null)
+            return threads.AsReadOnly();
+
+        var baseUri = new Uri(sectionUrl);
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var node in topicNodes)
+        {
+            var href = HtmlEntity.DeEntitize(node.GetAttributeValue("href", "")).Trim();
+            var title = HtmlEntity.DeEntitize(node.InnerText).Trim();
+
+            if (string.IsNullOrWhiteSpace(href) || string.IsNullOrWhiteSpace(title))
+                continue;
+
+            var resolvedUrl = ResolveUrl(baseUri, href);
+            if (!seen.Add(resolvedUrl))
+                continue;
+
+            threads.Add(new ForumThread
+            {
+                Url = resolvedUrl,
+                Title = title
+            });
+        }
+
+        return threads.AsReadOnly();
+    }
+
+    internal static IReadOnlyList<PostContent> ParsePostsFromHtml(HtmlDocument doc, string threadUrl)
+    {
+        var posts = new List<PostContent>();
+
+        // phpBB2: post bodies are in <span class="postbody"> or <td class="postbody">
+        var postNodes = doc.DocumentNode.SelectNodes(
+            "//span[contains(@class, 'postbody')] | //td[contains(@class, 'postbody')]");
+
+        // Fallback: look for div.postbody (phpBB3 style)
+        postNodes ??= doc.DocumentNode.SelectNodes("//div[contains(@class, 'postbody')]");
+
+        if (postNodes is null)
+            return posts.AsReadOnly();
+
+        int index = 0;
+        foreach (var node in postNodes)
+        {
+            var htmlContent = node.InnerHtml.Trim();
+            var plainText = HtmlEntity.DeEntitize(node.InnerText).Trim();
+
+            if (string.IsNullOrWhiteSpace(plainText))
+                continue;
+
+            posts.Add(new PostContent
+            {
+                ThreadUrl = threadUrl,
+                PostIndex = index++,
+                HtmlContent = htmlContent,
+                PlainTextContent = plainText
+            });
+        }
+
+        return posts.AsReadOnly();
+    }
+
+    internal static string? FindNextPageUrl(HtmlDocument doc, string currentUrl)
+    {
+        // phpBB2 pagination: look for "next" link in pagination area
+        // Pattern: <a href="viewforum.php?f=...&start=...">Next</a> or arrow image
+        var nextLink = doc.DocumentNode.SelectSingleNode(
+            "//span[@class='gensmall']//a[contains(text(), 'Next') or contains(text(), 'next')]");
+
+        // Also check for arrow-based navigation
+        nextLink ??= doc.DocumentNode.SelectSingleNode(
+            "//a[img[contains(@src, 'icon_next') or contains(@alt, 'Next')]]");
+
+        if (nextLink is null)
+            return null;
+
+        var href = HtmlEntity.DeEntitize(nextLink.GetAttributeValue("href", "")).Trim();
+        if (string.IsNullOrWhiteSpace(href))
+            return null;
+
+        return ResolveUrl(new Uri(currentUrl), href);
+    }
+
+    private static string ResolveUrl(Uri baseUri, string relativeUrl)
+    {
+        if (Uri.TryCreate(relativeUrl, UriKind.Absolute, out var absolute))
+            return absolute.AbsoluteUri;
+
+        if (Uri.TryCreate(baseUri, relativeUrl, out var resolved))
+            return resolved.AbsoluteUri;
+
+        return relativeUrl;
+    }
+}

--- a/src/SeriesScraper.Web/Program.cs
+++ b/src/SeriesScraper.Web/Program.cs
@@ -11,6 +11,7 @@ using SeriesScraper.Infrastructure.Repositories;
 using SeriesScraper.Infrastructure.BackgroundServices;
 using SeriesScraper.Infrastructure.Services;
 using SeriesScraper.Infrastructure.Services.Imdb;
+using SeriesScraper.Infrastructure.Services.Scrapers;
 using SeriesScraper.Web.BackgroundServices;
 using SeriesScraper.Web.Logging;
 
@@ -88,6 +89,9 @@ try
     builder.Services.AddSingleton<ILanguageTagParser, LanguageTagParser>();
     builder.Services.AddSingleton<IHtmlForumSectionParser, HtmlForumSectionParser>();
     builder.Services.AddSingleton<IResponseValidator, PhpBB2ResponseValidator>();
+
+    // Forum scraper (phpBB2 concrete implementation)
+    builder.Services.AddScoped<IForumScraper, PhpBB2ForumScraper>();
 
     // IMDB matching engine
     builder.Services.AddSingleton<ITitleNormalizer, TitleNormalizer>();

--- a/tests/SeriesScraper.Infrastructure.Tests/Services/Scrapers/PhpBB2ForumScraperTests.cs
+++ b/tests/SeriesScraper.Infrastructure.Tests/Services/Scrapers/PhpBB2ForumScraperTests.cs
@@ -1,0 +1,984 @@
+using System.Net;
+using FluentAssertions;
+using HtmlAgilityPack;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using SeriesScraper.Domain.Exceptions;
+using SeriesScraper.Domain.Interfaces;
+using SeriesScraper.Domain.ValueObjects;
+using SeriesScraper.Infrastructure.Services.Scrapers;
+
+namespace SeriesScraper.Infrastructure.Tests.Services.Scrapers;
+
+public class PhpBB2ForumScraperTests : IDisposable
+{
+    private readonly IHtmlForumSectionParser _sectionParser;
+    private readonly IResponseValidator _responseValidator;
+    private readonly ILogger<PhpBB2ForumScraper> _logger;
+    private readonly CookieContainer _cookieContainer;
+
+    private TestHttpMessageHandler _httpHandler = null!;
+    private HttpClient _httpClient = null!;
+    private PhpBB2ForumScraper _sut = null!;
+
+    private static readonly ForumCredentials ValidCredentials = new()
+    {
+        Username = "testuser",
+        Password = "testpass",
+        BaseUrl = "https://forum.example.com"
+    };
+
+    public PhpBB2ForumScraperTests()
+    {
+        _sectionParser = Substitute.For<IHtmlForumSectionParser>();
+        _responseValidator = Substitute.For<IResponseValidator>();
+        _logger = Substitute.For<ILogger<PhpBB2ForumScraper>>();
+        _cookieContainer = new CookieContainer();
+
+        // Default: responses are NOT expired
+        _responseValidator.IsSessionExpired(Arg.Any<string>()).Returns(false);
+
+        CreateSut("<html><body>Forum Home</body></html>");
+    }
+
+    private void CreateSut(string defaultResponse, HttpStatusCode statusCode = HttpStatusCode.OK)
+    {
+        _httpHandler?.Dispose();
+        _httpClient?.Dispose();
+
+        _httpHandler = new TestHttpMessageHandler(defaultResponse, statusCode);
+        _httpClient = new HttpClient(_httpHandler)
+        {
+            BaseAddress = new Uri("https://forum.example.com")
+        };
+        _sut = new PhpBB2ForumScraper(_sectionParser, _responseValidator, _logger, _httpClient, _cookieContainer);
+    }
+
+    public void Dispose()
+    {
+        _sut?.Dispose();
+        _httpClient?.Dispose();
+        _httpHandler?.Dispose();
+    }
+
+    // ===== Constructor Validation =====
+
+    [Fact]
+    public void Constructor_NullSectionParser_Throws()
+    {
+        var act = () => new PhpBB2ForumScraper(null!, _responseValidator, _logger);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("sectionParser");
+    }
+
+    [Fact]
+    public void Constructor_NullResponseValidator_Throws()
+    {
+        var act = () => new PhpBB2ForumScraper(_sectionParser, null!, _logger);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("responseValidator");
+    }
+
+    [Fact]
+    public void Constructor_NullLogger_Throws()
+    {
+        var act = () => new PhpBB2ForumScraper(_sectionParser, _responseValidator, null!);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("logger");
+    }
+
+    [Fact]
+    public void InternalConstructor_NullHttpClient_Throws()
+    {
+        var act = () => new PhpBB2ForumScraper(_sectionParser, _responseValidator, _logger, null!, _cookieContainer);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("httpClient");
+    }
+
+    [Fact]
+    public void InternalConstructor_NullCookieContainer_Throws()
+    {
+        using var client = new HttpClient();
+        var act = () => new PhpBB2ForumScraper(_sectionParser, _responseValidator, _logger, client, null!);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("cookieContainer");
+    }
+
+    // ===== AuthenticateAsync =====
+
+    [Fact]
+    public async Task AuthenticateAsync_NullCredentials_Throws()
+    {
+        var act = () => _sut.AuthenticateAsync(null!);
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_NullBaseUrl_ThrowsScrapingException()
+    {
+        var creds = new ForumCredentials { Username = "u", Password = "p", BaseUrl = null };
+        var act = () => _sut.AuthenticateAsync(creds);
+        await act.Should().ThrowAsync<ScrapingException>().WithMessage("*BaseUrl*");
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_EmptyBaseUrl_ThrowsScrapingException()
+    {
+        var creds = new ForumCredentials { Username = "u", Password = "p", BaseUrl = "   " };
+        var act = () => _sut.AuthenticateAsync(creds);
+        await act.Should().ThrowAsync<ScrapingException>().WithMessage("*BaseUrl*");
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_SuccessfulLogin_ReturnsTrue()
+    {
+        CreateSut("<html><body>Welcome back testuser</body></html>");
+        _responseValidator.IsSessionExpired(Arg.Any<string>()).Returns(false);
+
+        var result = await _sut.AuthenticateAsync(ValidCredentials);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_PostsToLoginPhp()
+    {
+        CreateSut("<html><body>Welcome</body></html>");
+        _responseValidator.IsSessionExpired(Arg.Any<string>()).Returns(false);
+
+        await _sut.AuthenticateAsync(ValidCredentials);
+
+        _httpHandler.LastRequestUri.Should().NotBeNull();
+        _httpHandler.LastRequestUri!.AbsoluteUri.Should().Be("https://forum.example.com/login.php");
+        _httpHandler.LastRequestMethod.Should().Be(HttpMethod.Post);
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_SendsCorrectFormData()
+    {
+        CreateSut("<html><body>Welcome</body></html>");
+        _responseValidator.IsSessionExpired(Arg.Any<string>()).Returns(false);
+
+        await _sut.AuthenticateAsync(ValidCredentials);
+
+        _httpHandler.LastRequestContent.Should().Contain("username=testuser");
+        _httpHandler.LastRequestContent.Should().Contain("password=testpass");
+        _httpHandler.LastRequestContent.Should().Contain("login=Log+in");
+        _httpHandler.LastRequestContent.Should().Contain("autologin=on");
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_LoginPageReturned_ReturnsFalse()
+    {
+        CreateSut("<html><form action='login.php'><input name='login'/></form></html>");
+        _responseValidator.IsSessionExpired(Arg.Any<string>()).Returns(true);
+
+        var result = await _sut.AuthenticateAsync(ValidCredentials);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_HttpError_ThrowsScrapingException()
+    {
+        CreateSut("", HttpStatusCode.InternalServerError);
+
+        var act = () => _sut.AuthenticateAsync(ValidCredentials);
+
+        await act.Should().ThrowAsync<ScrapingException>().WithMessage("*Network error*");
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_TrailingSlashInBaseUrl_HandledCorrectly()
+    {
+        CreateSut("<html><body>Welcome</body></html>");
+        _responseValidator.IsSessionExpired(Arg.Any<string>()).Returns(false);
+
+        var creds = ValidCredentials with { BaseUrl = "https://forum.example.com/" };
+        await _sut.AuthenticateAsync(creds);
+
+        _httpHandler.LastRequestUri!.AbsoluteUri.Should().Be("https://forum.example.com/login.php");
+    }
+
+    // ===== GetCookieContainer =====
+
+    [Fact]
+    public void GetCookieContainer_ReturnsCookieContainer()
+    {
+        var container = _sut.GetCookieContainer();
+        container.Should().BeSameAs(_cookieContainer);
+    }
+
+    // ===== ValidateSessionAsync =====
+
+    [Fact]
+    public async Task ValidateSessionAsync_NoAuthentication_ReturnsFalse()
+    {
+        var result = await _sut.ValidateSessionAsync();
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ValidateSessionAsync_AfterAuth_ValidSession_ReturnsTrue()
+    {
+        CreateSut("<html><body>Forum content</body></html>");
+        _responseValidator.IsSessionExpired(Arg.Any<string>()).Returns(false);
+
+        await _sut.AuthenticateAsync(ValidCredentials);
+        var result = await _sut.ValidateSessionAsync();
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ValidateSessionAsync_AfterAuth_ExpiredSession_ReturnsFalse()
+    {
+        CreateSut("<html><body>Content</body></html>");
+        // First call (auth) returns false (not expired), second call (validate) returns true (expired)
+        _responseValidator.IsSessionExpired(Arg.Any<string>())
+            .Returns(false, true);
+
+        await _sut.AuthenticateAsync(ValidCredentials);
+        var result = await _sut.ValidateSessionAsync();
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ValidateSessionAsync_HttpError_ReturnsFalse()
+    {
+        // First authenticate successfully
+        CreateSut("<html><body>Welcome</body></html>");
+        _responseValidator.IsSessionExpired(Arg.Any<string>()).Returns(false);
+        await _sut.AuthenticateAsync(ValidCredentials);
+
+        // Then make next request fail
+        _httpHandler.SetNextResponse("", HttpStatusCode.InternalServerError);
+
+        var result = await _sut.ValidateSessionAsync();
+        result.Should().BeFalse();
+    }
+
+    // ===== EnumerateSectionsAsync =====
+
+    [Fact]
+    public async Task EnumerateSectionsAsync_NullBaseUrl_Throws()
+    {
+        var act = async () =>
+        {
+            await foreach (var _ in _sut.EnumerateSectionsAsync(null!)) { }
+        };
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task EnumerateSectionsAsync_DepthLessThanOne_Throws()
+    {
+        var act = async () =>
+        {
+            await foreach (var _ in _sut.EnumerateSectionsAsync("https://forum.example.com", 0)) { }
+        };
+        await act.Should().ThrowAsync<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public async Task EnumerateSectionsAsync_ReturnsSectionsFromParser()
+    {
+        var expectedSections = new[]
+        {
+            new ForumSection { Url = "https://forum.example.com/viewforum.php?f=1", Name = "Section 1", Depth = 1 },
+            new ForumSection { Url = "https://forum.example.com/viewforum.php?f=2", Name = "Section 2", Depth = 1 }
+        };
+
+        _sectionParser.ParseSections(Arg.Any<string>(), Arg.Any<string>())
+            .Returns(expectedSections);
+
+        var results = new List<ForumSection>();
+        await foreach (var section in _sut.EnumerateSectionsAsync("https://forum.example.com"))
+        {
+            results.Add(section);
+        }
+
+        results.Should().HaveCount(2);
+        results[0].Name.Should().Be("Section 1");
+        results[1].Name.Should().Be("Section 2");
+    }
+
+    [Fact]
+    public async Task EnumerateSectionsAsync_FetchesIndexPhp()
+    {
+        _sectionParser.ParseSections(Arg.Any<string>(), Arg.Any<string>())
+            .Returns(Array.Empty<ForumSection>());
+
+        await foreach (var _ in _sut.EnumerateSectionsAsync("https://forum.example.com")) { }
+
+        _httpHandler.LastRequestUri!.AbsoluteUri.Should().Be("https://forum.example.com/index.php");
+    }
+
+    [Fact]
+    public async Task EnumerateSectionsAsync_HttpError_ThrowsScrapingException()
+    {
+        CreateSut("", HttpStatusCode.InternalServerError);
+
+        var act = async () =>
+        {
+            await foreach (var _ in _sut.EnumerateSectionsAsync("https://forum.example.com")) { }
+        };
+        await act.Should().ThrowAsync<ScrapingException>();
+    }
+
+    [Fact]
+    public async Task EnumerateSectionsAsync_Depth2_RecursesIntoSubSections()
+    {
+        var topSections = new[]
+        {
+            new ForumSection { Url = "https://forum.example.com/viewforum.php?f=1", Name = "Top", Depth = 1 }
+        };
+
+        var subSections = new[]
+        {
+            new ForumSection { Url = "https://forum.example.com/viewforum.php?f=10", Name = "Sub", Depth = 1 }
+        };
+
+        // First call (index page) returns top-level sections
+        // Second call (sub-section page) returns sub-sections
+        _sectionParser.ParseSections(Arg.Any<string>(), Arg.Any<string>())
+            .Returns(topSections, subSections);
+
+        var results = new List<ForumSection>();
+        await foreach (var section in _sut.EnumerateSectionsAsync("https://forum.example.com", depth: 2))
+        {
+            results.Add(section);
+        }
+
+        results.Should().HaveCount(2);
+        results[0].Name.Should().Be("Top");
+        results[0].Depth.Should().Be(1);
+        results[1].Name.Should().Be("Sub");
+        results[1].Depth.Should().Be(2);
+        results[1].ParentUrl.Should().Be("https://forum.example.com/viewforum.php?f=1");
+    }
+
+    [Fact]
+    public async Task EnumerateSectionsAsync_Cancellation_StopsEnumeration()
+    {
+        var sections = new[]
+        {
+            new ForumSection { Url = "https://forum.example.com/viewforum.php?f=1", Name = "S1", Depth = 1 },
+            new ForumSection { Url = "https://forum.example.com/viewforum.php?f=2", Name = "S2", Depth = 1 }
+        };
+
+        _sectionParser.ParseSections(Arg.Any<string>(), Arg.Any<string>())
+            .Returns(sections);
+
+        using var cts = new CancellationTokenSource();
+        var results = new List<ForumSection>();
+
+        try
+        {
+            await foreach (var section in _sut.EnumerateSectionsAsync("https://forum.example.com", cancellationToken: cts.Token))
+            {
+                results.Add(section);
+                cts.Cancel(); // Cancel after first — next MoveNextAsync will throw
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected — cancellation triggered on next iteration
+        }
+
+        results.Should().HaveCount(1);
+    }
+
+    // ===== EnumerateThreadsAsync =====
+
+    [Fact]
+    public async Task EnumerateThreadsAsync_NullSectionUrl_Throws()
+    {
+        var act = async () =>
+        {
+            await foreach (var _ in _sut.EnumerateThreadsAsync(null!)) { }
+        };
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task EnumerateThreadsAsync_ParsesPhpBB2Threads()
+    {
+        var html = @"<html><body>
+            <table>
+                <tr>
+                    <td class='row1'>
+                        <a class='topictitle' href='viewtopic.php?t=100'>Movie Download</a>
+                    </td>
+                </tr>
+                <tr>
+                    <td class='row1'>
+                        <a class='topictitle' href='viewtopic.php?t=200'>Series Episode S01E01</a>
+                    </td>
+                </tr>
+            </table>
+        </body></html>";
+
+        CreateSut(html);
+
+        var results = new List<ForumThread>();
+        await foreach (var thread in _sut.EnumerateThreadsAsync("https://forum.example.com/viewforum.php?f=1"))
+        {
+            results.Add(thread);
+        }
+
+        results.Should().HaveCount(2);
+        results[0].Title.Should().Be("Movie Download");
+        results[0].Url.Should().Contain("viewtopic.php?t=100");
+        results[1].Title.Should().Be("Series Episode S01E01");
+    }
+
+    [Fact]
+    public async Task EnumerateThreadsAsync_FallbackToRowClassLinks()
+    {
+        var html = @"<html><body>
+            <table>
+                <tr>
+                    <td class='row1'>
+                        <a href='viewtopic.php?t=300'>Fallback Thread</a>
+                    </td>
+                </tr>
+            </table>
+        </body></html>";
+
+        CreateSut(html);
+
+        var results = new List<ForumThread>();
+        await foreach (var thread in _sut.EnumerateThreadsAsync("https://forum.example.com/viewforum.php?f=1"))
+        {
+            results.Add(thread);
+        }
+
+        results.Should().HaveCount(1);
+        results[0].Title.Should().Be("Fallback Thread");
+    }
+
+    [Fact]
+    public async Task EnumerateThreadsAsync_NoThreads_ReturnsEmpty()
+    {
+        CreateSut("<html><body><p>Empty section</p></body></html>");
+
+        var results = new List<ForumThread>();
+        await foreach (var thread in _sut.EnumerateThreadsAsync("https://forum.example.com/viewforum.php?f=1"))
+        {
+            results.Add(thread);
+        }
+
+        results.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task EnumerateThreadsAsync_DuplicateThreads_Deduplicated()
+    {
+        var html = @"<html><body>
+            <table>
+                <tr><td class='row1'><a class='topictitle' href='viewtopic.php?t=100'>Thread</a></td></tr>
+                <tr><td class='row1'><a class='topictitle' href='viewtopic.php?t=100'>Thread</a></td></tr>
+            </table>
+        </body></html>";
+
+        CreateSut(html);
+
+        var results = new List<ForumThread>();
+        await foreach (var thread in _sut.EnumerateThreadsAsync("https://forum.example.com/viewforum.php?f=1"))
+        {
+            results.Add(thread);
+        }
+
+        results.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task EnumerateThreadsAsync_HttpError_ThrowsScrapingException()
+    {
+        CreateSut("", HttpStatusCode.InternalServerError);
+
+        var act = async () =>
+        {
+            await foreach (var _ in _sut.EnumerateThreadsAsync("https://forum.example.com/viewforum.php?f=1")) { }
+        };
+        await act.Should().ThrowAsync<ScrapingException>();
+    }
+
+    [Fact]
+    public async Task EnumerateThreadsAsync_WithPagination_FollowsNextPage()
+    {
+        var page1 = @"<html><body>
+            <table>
+                <tr><td class='row1'><a class='topictitle' href='viewtopic.php?t=1'>Thread 1</a></td></tr>
+            </table>
+            <span class='gensmall'><a href='viewforum.php?f=1&amp;start=25'>Next</a></span>
+        </body></html>";
+
+        var page2 = @"<html><body>
+            <table>
+                <tr><td class='row1'><a class='topictitle' href='viewtopic.php?t=2'>Thread 2</a></td></tr>
+            </table>
+        </body></html>";
+
+        _httpHandler?.Dispose();
+        _httpClient?.Dispose();
+        _httpHandler = new TestHttpMessageHandler(new Queue<string>(new[] { page1, page2 }));
+        _httpClient = new HttpClient(_httpHandler) { BaseAddress = new Uri("https://forum.example.com") };
+        _sut = new PhpBB2ForumScraper(_sectionParser, _responseValidator, _logger, _httpClient, _cookieContainer);
+
+        var results = new List<ForumThread>();
+        await foreach (var thread in _sut.EnumerateThreadsAsync("https://forum.example.com/viewforum.php?f=1"))
+        {
+            results.Add(thread);
+        }
+
+        results.Should().HaveCount(2);
+        results[0].Title.Should().Be("Thread 1");
+        results[1].Title.Should().Be("Thread 2");
+    }
+
+    // ===== ExtractPostContentAsync =====
+
+    [Fact]
+    public async Task ExtractPostContentAsync_NullThreadUrl_Throws()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(() => _sut.ExtractPostContentAsync(null!));
+    }
+
+    [Fact]
+    public async Task ExtractPostContentAsync_ParsesPhpBB2Posts()
+    {
+        var html = @"<html><body>
+            <span class='postbody'>First post content with <b>bold</b> text</span>
+            <span class='postbody'>Second post reply</span>
+        </body></html>";
+
+        CreateSut(html);
+
+        var posts = await _sut.ExtractPostContentAsync("https://forum.example.com/viewtopic.php?t=100");
+
+        posts.Should().HaveCount(2);
+        posts[0].ThreadUrl.Should().Be("https://forum.example.com/viewtopic.php?t=100");
+        posts[0].PostIndex.Should().Be(0);
+        posts[0].HtmlContent.Should().Contain("bold");
+        posts[0].PlainTextContent.Should().Contain("First post content");
+        posts[1].PostIndex.Should().Be(1);
+        posts[1].PlainTextContent.Should().Contain("Second post reply");
+    }
+
+    [Fact]
+    public async Task ExtractPostContentAsync_TdPostbody_AlsoParsed()
+    {
+        var html = @"<html><body>
+            <td class='postbody'>Post in table cell</td>
+        </body></html>";
+
+        CreateSut(html);
+
+        var posts = await _sut.ExtractPostContentAsync("https://forum.example.com/viewtopic.php?t=100");
+
+        posts.Should().HaveCount(1);
+        posts[0].PlainTextContent.Should().Contain("Post in table cell");
+    }
+
+    [Fact]
+    public async Task ExtractPostContentAsync_DivPostbody_FallbackParsed()
+    {
+        var html = @"<html><body>
+            <div class='postbody'>phpBB3 style post</div>
+        </body></html>";
+
+        CreateSut(html);
+
+        var posts = await _sut.ExtractPostContentAsync("https://forum.example.com/viewtopic.php?t=100");
+
+        posts.Should().HaveCount(1);
+        posts[0].PlainTextContent.Should().Contain("phpBB3 style post");
+    }
+
+    [Fact]
+    public async Task ExtractPostContentAsync_NoPosts_ReturnsEmpty()
+    {
+        CreateSut("<html><body><p>No posts here</p></body></html>");
+
+        var posts = await _sut.ExtractPostContentAsync("https://forum.example.com/viewtopic.php?t=100");
+
+        posts.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExtractPostContentAsync_EmptyPosts_Skipped()
+    {
+        var html = @"<html><body>
+            <span class='postbody'>   </span>
+            <span class='postbody'>Real content</span>
+        </body></html>";
+
+        CreateSut(html);
+
+        var posts = await _sut.ExtractPostContentAsync("https://forum.example.com/viewtopic.php?t=100");
+
+        posts.Should().HaveCount(1);
+        posts[0].PlainTextContent.Should().Contain("Real content");
+    }
+
+    [Fact]
+    public async Task ExtractPostContentAsync_HttpError_ThrowsScrapingException()
+    {
+        CreateSut("", HttpStatusCode.InternalServerError);
+
+        var act = () => _sut.ExtractPostContentAsync("https://forum.example.com/viewtopic.php?t=100");
+        await act.Should().ThrowAsync<ScrapingException>();
+    }
+
+    // ===== ExtractLinksAsync =====
+
+    [Fact]
+    public async Task ExtractLinksAsync_NullPostContent_Throws()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(() => _sut.ExtractLinksAsync(null!));
+    }
+
+    [Fact]
+    public async Task ExtractLinksAsync_ExtractsExternalLinks()
+    {
+        var post = new PostContent
+        {
+            ThreadUrl = "https://forum.example.com/viewtopic.php?t=100",
+            PostIndex = 0,
+            HtmlContent = @"
+                <a href='https://download.example.com/file.rar'>Download Here</a>
+                <a href='https://mega.nz/file/abc'>Mega Link</a>",
+            PlainTextContent = "Download Here Mega Link"
+        };
+
+        var links = await _sut.ExtractLinksAsync(post);
+
+        links.Should().HaveCount(2);
+        links[0].Url.Should().Be("https://download.example.com/file.rar");
+        links[0].Scheme.Should().Be("https");
+        links[0].LinkText.Should().Be("Download Here");
+        links[1].Url.Should().Be("https://mega.nz/file/abc");
+    }
+
+    [Fact]
+    public async Task ExtractLinksAsync_SkipsInternalForumLinks()
+    {
+        var post = new PostContent
+        {
+            ThreadUrl = "https://forum.example.com/viewtopic.php?t=100",
+            PostIndex = 0,
+            HtmlContent = @"
+                <a href='viewtopic.php?t=200'>Another thread</a>
+                <a href='viewforum.php?f=5'>Section</a>
+                <a href='login.php'>Login</a>
+                <a href='profile.php?mode=viewprofile'>Profile</a>
+                <a href='posting.php?mode=reply'>Reply</a>
+                <a href='memberlist.php'>Members</a>
+                <a href='https://download.example.com/real.zip'>Real Link</a>",
+            PlainTextContent = "text"
+        };
+
+        var links = await _sut.ExtractLinksAsync(post);
+
+        links.Should().HaveCount(1);
+        links[0].Url.Should().Contain("download.example.com");
+    }
+
+    [Fact]
+    public async Task ExtractLinksAsync_SkipsAnchors()
+    {
+        var post = new PostContent
+        {
+            ThreadUrl = "https://forum.example.com/viewtopic.php?t=100",
+            PostIndex = 0,
+            HtmlContent = "<a href='#top'>Top</a>",
+            PlainTextContent = "Top"
+        };
+
+        var links = await _sut.ExtractLinksAsync(post);
+        links.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExtractLinksAsync_SkipsRelativeNonAbsoluteLinks()
+    {
+        var post = new PostContent
+        {
+            ThreadUrl = "https://forum.example.com/viewtopic.php?t=100",
+            PostIndex = 0,
+            HtmlContent = "<a href='some/relative/path'>Relative</a>",
+            PlainTextContent = "Relative"
+        };
+
+        var links = await _sut.ExtractLinksAsync(post);
+        links.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExtractLinksAsync_NoLinks_ReturnsEmpty()
+    {
+        var post = new PostContent
+        {
+            ThreadUrl = "https://forum.example.com/viewtopic.php?t=100",
+            PostIndex = 0,
+            HtmlContent = "<p>Just text, no links</p>",
+            PlainTextContent = "Just text, no links"
+        };
+
+        var links = await _sut.ExtractLinksAsync(post);
+        links.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExtractLinksAsync_EmptyHref_Skipped()
+    {
+        var post = new PostContent
+        {
+            ThreadUrl = "https://forum.example.com/viewtopic.php?t=100",
+            PostIndex = 0,
+            HtmlContent = "<a href=''>Empty</a><a href='   '>Whitespace</a>",
+            PlainTextContent = "Empty Whitespace"
+        };
+
+        var links = await _sut.ExtractLinksAsync(post);
+        links.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExtractLinksAsync_HtmlEntitiesDecoded()
+    {
+        var post = new PostContent
+        {
+            ThreadUrl = "https://forum.example.com/viewtopic.php?t=100",
+            PostIndex = 0,
+            HtmlContent = "<a href='https://example.com/file?a=1&amp;b=2'>Link</a>",
+            PlainTextContent = "Link"
+        };
+
+        var links = await _sut.ExtractLinksAsync(post);
+        links.Should().HaveCount(1);
+        links[0].Url.Should().Be("https://example.com/file?a=1&b=2");
+    }
+
+    [Fact]
+    public async Task ExtractLinksAsync_EmptyLinkText_SetsNull()
+    {
+        var post = new PostContent
+        {
+            ThreadUrl = "https://forum.example.com/viewtopic.php?t=100",
+            PostIndex = 0,
+            HtmlContent = "<a href='https://example.com/file.zip'></a>",
+            PlainTextContent = ""
+        };
+
+        var links = await _sut.ExtractLinksAsync(post);
+        links.Should().HaveCount(1);
+        links[0].LinkText.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ExtractLinksAsync_MagnetLinks_Extracted()
+    {
+        var post = new PostContent
+        {
+            ThreadUrl = "https://forum.example.com/viewtopic.php?t=100",
+            PostIndex = 0,
+            HtmlContent = "<a href='magnet:?xt=urn:btih:abc123'>Torrent</a>",
+            PlainTextContent = "Torrent"
+        };
+
+        var links = await _sut.ExtractLinksAsync(post);
+        links.Should().HaveCount(1);
+        links[0].Scheme.Should().Be("magnet");
+    }
+
+    // ===== Static HTML Parsing Tests =====
+
+    [Fact]
+    public void ParseThreadsFromHtml_TopicTitleLinks()
+    {
+        var doc = new HtmlDocument();
+        doc.LoadHtml(@"<html><body>
+            <a class='topictitle' href='viewtopic.php?t=1'>Thread One</a>
+            <a class='topictitle' href='viewtopic.php?t=2'>Thread Two</a>
+        </body></html>");
+
+        var threads = PhpBB2ForumScraper.ParseThreadsFromHtml(doc, "https://forum.example.com/viewforum.php?f=1");
+
+        threads.Should().HaveCount(2);
+        threads[0].Title.Should().Be("Thread One");
+        threads[1].Title.Should().Be("Thread Two");
+    }
+
+    [Fact]
+    public void ParseThreadsFromHtml_EmptyTitle_Skipped()
+    {
+        var doc = new HtmlDocument();
+        doc.LoadHtml(@"<html><body>
+            <a class='topictitle' href='viewtopic.php?t=1'>  </a>
+            <a class='topictitle' href='viewtopic.php?t=2'>Valid</a>
+        </body></html>");
+
+        var threads = PhpBB2ForumScraper.ParseThreadsFromHtml(doc, "https://forum.example.com/viewforum.php?f=1");
+
+        threads.Should().HaveCount(1);
+        threads[0].Title.Should().Be("Valid");
+    }
+
+    [Fact]
+    public void ParseThreadsFromHtml_EmptyHref_Skipped()
+    {
+        var doc = new HtmlDocument();
+        doc.LoadHtml(@"<html><body>
+            <a class='topictitle' href=''>No href</a>
+        </body></html>");
+
+        var threads = PhpBB2ForumScraper.ParseThreadsFromHtml(doc, "https://forum.example.com/viewforum.php?f=1");
+        threads.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ParseThreadsFromHtml_ResolvesRelativeUrls()
+    {
+        var doc = new HtmlDocument();
+        doc.LoadHtml(@"<html><body>
+            <a class='topictitle' href='viewtopic.php?t=5'>Thread</a>
+        </body></html>");
+
+        var threads = PhpBB2ForumScraper.ParseThreadsFromHtml(doc, "https://forum.example.com/viewforum.php?f=1");
+
+        threads[0].Url.Should().StartWith("https://forum.example.com/");
+        threads[0].Url.Should().Contain("viewtopic.php?t=5");
+    }
+
+    [Fact]
+    public void ParsePostsFromHtml_SpanPostbody()
+    {
+        var doc = new HtmlDocument();
+        doc.LoadHtml(@"<html><body>
+            <span class='postbody'>Hello <b>world</b></span>
+        </body></html>");
+
+        var posts = PhpBB2ForumScraper.ParsePostsFromHtml(doc, "https://forum.example.com/viewtopic.php?t=1");
+
+        posts.Should().HaveCount(1);
+        posts[0].HtmlContent.Should().Contain("<b>world</b>");
+        posts[0].PlainTextContent.Should().Contain("Hello world");
+    }
+
+    [Fact]
+    public void ParsePostsFromHtml_NoPostElements_ReturnsEmpty()
+    {
+        var doc = new HtmlDocument();
+        doc.LoadHtml("<html><body><p>No posts</p></body></html>");
+
+        var posts = PhpBB2ForumScraper.ParsePostsFromHtml(doc, "https://forum.example.com/viewtopic.php?t=1");
+        posts.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void FindNextPageUrl_WithNextLink_ReturnsUrl()
+    {
+        var doc = new HtmlDocument();
+        doc.LoadHtml(@"<html><body>
+            <span class='gensmall'>
+                <a href='viewforum.php?f=1&amp;start=25'>Next</a>
+            </span>
+        </body></html>");
+
+        var next = PhpBB2ForumScraper.FindNextPageUrl(doc, "https://forum.example.com/viewforum.php?f=1");
+        next.Should().NotBeNull();
+        next.Should().Contain("start=25");
+    }
+
+    [Fact]
+    public void FindNextPageUrl_NoNextLink_ReturnsNull()
+    {
+        var doc = new HtmlDocument();
+        doc.LoadHtml("<html><body><p>No pagination</p></body></html>");
+
+        var next = PhpBB2ForumScraper.FindNextPageUrl(doc, "https://forum.example.com/viewforum.php?f=1");
+        next.Should().BeNull();
+    }
+
+    [Fact]
+    public void FindNextPageUrl_WithIconNext_ReturnsUrl()
+    {
+        var doc = new HtmlDocument();
+        doc.LoadHtml(@"<html><body>
+            <a href='viewforum.php?f=1&amp;start=50'><img src='icon_next.gif' alt='Next'/></a>
+        </body></html>");
+
+        var next = PhpBB2ForumScraper.FindNextPageUrl(doc, "https://forum.example.com/viewforum.php?f=1");
+        next.Should().NotBeNull();
+        next.Should().Contain("start=50");
+    }
+
+    // ===== Dispose =====
+
+    [Fact]
+    public void Dispose_CanBeCalledMultipleTimes()
+    {
+        var scraper = new PhpBB2ForumScraper(_sectionParser, _responseValidator, _logger);
+        scraper.Dispose();
+        scraper.Dispose(); // Should not throw
+    }
+
+    // ===== TestHttpMessageHandler =====
+
+    private sealed class TestHttpMessageHandler : HttpMessageHandler
+    {
+        private string _responseContent;
+        private HttpStatusCode _statusCode;
+        private readonly Queue<string>? _responseQueue;
+
+        public Uri? LastRequestUri { get; private set; }
+        public HttpMethod? LastRequestMethod { get; private set; }
+        public string? LastRequestContent { get; private set; }
+
+        public TestHttpMessageHandler(string responseContent, HttpStatusCode statusCode = HttpStatusCode.OK)
+        {
+            _responseContent = responseContent;
+            _statusCode = statusCode;
+        }
+
+        public TestHttpMessageHandler(Queue<string> responses, HttpStatusCode statusCode = HttpStatusCode.OK)
+        {
+            _responseQueue = responses;
+            _responseContent = "";
+            _statusCode = statusCode;
+        }
+
+        public void SetNextResponse(string content, HttpStatusCode statusCode = HttpStatusCode.OK)
+        {
+            _responseContent = content;
+            _statusCode = statusCode;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastRequestUri = request.RequestUri;
+            LastRequestMethod = request.Method;
+
+            if (request.Content is not null)
+            {
+                LastRequestContent = await request.Content.ReadAsStringAsync(cancellationToken);
+            }
+
+            var content = _responseQueue is not null && _responseQueue.Count > 0
+                ? _responseQueue.Dequeue()
+                : _responseContent;
+
+            var response = new HttpResponseMessage(_statusCode)
+            {
+                Content = new StringContent(content)
+            };
+
+            if (_statusCode != HttpStatusCode.OK)
+            {
+                response.EnsureSuccessStatusCode(); // Throw for non-success
+            }
+
+            return response;
+        }
+    }
+}


### PR DESCRIPTION
Closes #99

## Summary
Implements PhpBB2ForumScraper : IForumScraper — the concrete phpBB2 scraper that composes existing infrastructure services behind the IForumScraper interface contract.

## Changes
- **New:** src/SeriesScraper.Infrastructure/Services/Scrapers/PhpBB2ForumScraper.cs — full implementation of all 7 IForumScraper members
- **New:** 	ests/SeriesScraper.Infrastructure.Tests/Services/Scrapers/PhpBB2ForumScraperTests.cs — 60 unit tests with mocked HTTP layer
- **Modified:** src/SeriesScraper.Domain/ValueObjects/ForumCredentials.cs — added optional \BaseUrl\ property for auth URL resolution
- **Modified:** src/SeriesScraper.Application/Services/ForumSessionManager.cs — passes \BaseUrl\ when constructing credentials
- **Modified:** src/SeriesScraper.Web/Program.cs — registers \PhpBB2ForumScraper\ as \IForumScraper\ in DI

## Implementation Details
- Composes \IHtmlForumSectionParser\ for section discovery and \IResponseValidator\ for session expiry detection
- Manages its own \CookieContainer\ + \HttpClient\ for phpBB2 HTTP communication
- Handles phpBB2-specific HTML parsing: \	opictitle\ links for threads, \postbody\ spans/tds for posts
- Supports pagination via phpBB2 \gensmall\ next-page links
- Filters out internal forum links (viewtopic, viewforum, login, profile, etc.) during link extraction
- Recursive section enumeration for configurable crawl depth

## Testing
- 60 new unit tests covering all IForumScraper members, constructor validation, HTML parsing, pagination, error handling, and cancellation
- All 1425 tests pass (196 Domain + 610 Application + 33 Web + 586 Infrastructure)
- No regressions in existing tests

## Known Limitations
- Encoding-aware response reading deferred to higher-level services (ForumSessionManager already handles this)