### PR TITLE
feat(#104): Manual thread URL submission

### DIFF
--- a/src/SeriesScraper.Application/Services/ScrapeRunService.cs
+++ b/src/SeriesScraper.Application/Services/ScrapeRunService.cs
@@ -15,17 +15,23 @@ public class ScrapeRunService : IScrapeRunService
     private readonly IScrapeRunRepository _repository;
     private readonly IScrapingJobQueue _jobQueue;
     private readonly IScrapeOrchestrator _orchestrator;
+    private readonly IForumRepository _forumRepository;
+    private readonly IUrlValidator _urlValidator;
     private readonly ILogger<ScrapeRunService> _logger;
 
     public ScrapeRunService(
         IScrapeRunRepository repository,
         IScrapingJobQueue jobQueue,
         IScrapeOrchestrator orchestrator,
+        IForumRepository forumRepository,
+        IUrlValidator urlValidator,
         ILogger<ScrapeRunService> logger)
     {
         _repository = repository;
         _jobQueue = jobQueue;
         _orchestrator = orchestrator;
+        _forumRepository = forumRepository;
+        _urlValidator = urlValidator;
         _logger = logger;
     }
 
@@ -54,6 +60,61 @@ public class ScrapeRunService : IScrapeRunService
         };
         await _jobQueue.EnqueueAsync(job, ct);
         _logger.LogInformation("Enqueued scrape run {RunId} for forum {ForumId}", run.RunId, forumId);
+    }
+
+    public async Task<ScrapeRun> ScrapeByUrlAsync(string threadUrl, int forumId, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(threadUrl))
+            throw new ArgumentException("Thread URL is required.", nameof(threadUrl));
+
+        // SSRF check via existing IUrlValidator
+        if (!_urlValidator.IsUrlSafe(threadUrl, out var reason))
+            throw new ArgumentException($"URL blocked: {reason}", nameof(threadUrl));
+
+        // Must be a viewtopic.php URL
+        if (!Uri.TryCreate(threadUrl, UriKind.Absolute, out var parsedUri)
+            || !parsedUri.AbsolutePath.Contains("viewtopic.php", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ArgumentException("URL must be a viewtopic.php thread URL.", nameof(threadUrl));
+        }
+
+        // Validate URL matches the forum's base URL
+        var forum = await _forumRepository.GetByIdAsync(forumId, ct)
+            ?? throw new InvalidOperationException($"Forum {forumId} not found.");
+
+        if (!Uri.TryCreate(forum.BaseUrl, UriKind.Absolute, out var baseUri)
+            || !string.Equals(parsedUri.Host, baseUri.Host, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ArgumentException(
+                $"URL host '{parsedUri.Host}' does not match forum base URL '{forum.BaseUrl}'.",
+                nameof(threadUrl));
+        }
+
+        // Create a run with SingleThread type
+        var run = new ScrapeRun
+        {
+            ForumId = forumId,
+            Status = ScrapeRunStatus.Pending,
+            RunType = ScrapeRunType.SingleThread,
+            StartedAt = DateTime.UtcNow
+        };
+
+        run = await _repository.CreateAsync(run, ct);
+
+        // Enqueue with the single URL as PostUrls
+        var job = new ScrapeJob
+        {
+            RunId = run.RunId,
+            ForumId = forumId,
+            PostUrls = new[] { threadUrl }
+        };
+
+        await _jobQueue.EnqueueAsync(job, ct);
+        _logger.LogInformation(
+            "Enqueued single-thread scrape run {RunId} for forum {ForumId}, URL: {Url}",
+            run.RunId, forumId, threadUrl);
+
+        return run;
     }
 
     public async Task ProcessJobAsync(ScrapeJob job, CancellationToken ct = default)

--- a/src/SeriesScraper.Domain/Entities/ScrapeRun.cs
+++ b/src/SeriesScraper.Domain/Entities/ScrapeRun.cs
@@ -22,6 +22,12 @@ public class ScrapeRun
     /// </summary>
     public ScrapeRunStatus Status { get; set; } = ScrapeRunStatus.Pending;
     
+    /// <summary>
+    /// Discriminates how this run was initiated (search-based or single-thread URL).
+    /// Stored as string via HasConversion&lt;string&gt;().
+    /// </summary>
+    public ScrapeRunType RunType { get; set; } = ScrapeRunType.Search;
+    
     public DateTime StartedAt { get; set; }
     
     /// <summary>

--- a/src/SeriesScraper.Domain/Enums/ScrapeRunType.cs
+++ b/src/SeriesScraper.Domain/Enums/ScrapeRunType.cs
@@ -1,0 +1,11 @@
+namespace SeriesScraper.Domain.Enums;
+
+/// <summary>
+/// Discriminates how a scrape run was initiated.
+/// Stored as string in database via HasConversion&lt;string&gt;() per ADR-004.
+/// </summary>
+public enum ScrapeRunType
+{
+    Search,
+    SingleThread
+}

--- a/src/SeriesScraper.Domain/Interfaces/IScrapeRunService.cs
+++ b/src/SeriesScraper.Domain/Interfaces/IScrapeRunService.cs
@@ -11,6 +11,7 @@ public interface IScrapeRunService
 {
     Task<ScrapeRun> CreateRunAsync(int forumId, CancellationToken ct = default);
     Task EnqueueRunAsync(int forumId, IReadOnlySet<string>? skipUrls = null, CancellationToken ct = default);
+    Task<ScrapeRun> ScrapeByUrlAsync(string threadUrl, int forumId, CancellationToken ct = default);
     Task ProcessJobAsync(ScrapeJob job, CancellationToken ct = default);
     Task CompleteRunAsync(int runId, CancellationToken ct = default);
     Task FailRunAsync(int runId, CancellationToken ct = default);

--- a/src/SeriesScraper.Infrastructure/Data/Configurations/ScrapeRunConfiguration.cs
+++ b/src/SeriesScraper.Infrastructure/Data/Configurations/ScrapeRunConfiguration.cs
@@ -20,6 +20,12 @@ public class ScrapeRunConfiguration : IEntityTypeConfiguration<ScrapeRun>
             .IsRequired()
             .HasMaxLength(50);
         
+        entity.Property(e => e.RunType)
+            .HasConversion<string>()
+            .IsRequired()
+            .HasMaxLength(50)
+            .HasDefaultValue(Domain.Enums.ScrapeRunType.Search);
+        
         entity.Property(e => e.StartedAt)
             .HasColumnType("timestamp with time zone")
             .HasDefaultValueSql("CURRENT_TIMESTAMP");

--- a/src/SeriesScraper.Infrastructure/Migrations/20260403164053_AddScrapeRunType.Designer.cs
+++ b/src/SeriesScraper.Infrastructure/Migrations/20260403164053_AddScrapeRunType.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SeriesScraper.Infrastructure.Data;
@@ -11,9 +12,11 @@ using SeriesScraper.Infrastructure.Data;
 namespace SeriesScraper.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260403164053_AddScrapeRunType")]
+    partial class AddScrapeRunType
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -21,31 +24,6 @@ namespace SeriesScraper.Infrastructure.Migrations
                 .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
-
-            modelBuilder.Entity("Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.DataProtectionKey", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("integer")
-                        .HasColumnName("id");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
-
-                    b.Property<string>("FriendlyName")
-                        .HasMaxLength(500)
-                        .HasColumnType("character varying(500)")
-                        .HasColumnName("friendly_name");
-
-                    b.Property<string>("Xml")
-                        .IsRequired()
-                        .HasColumnType("text")
-                        .HasColumnName("xml");
-
-                    b.HasKey("Id")
-                        .HasName("pk_data_protection_keys");
-
-                    b.ToTable("data_protection_keys", (string)null);
-                });
 
             modelBuilder.Entity("SeriesScraper.Domain.Entities.ContentType", b =>
                 {
@@ -540,11 +518,6 @@ namespace SeriesScraper.Infrastructure.Migrations
                         .HasColumnType("boolean")
                         .HasDefaultValue(true)
                         .HasColumnName("is_current");
-
-                    b.Property<string>("Language")
-                        .HasMaxLength(50)
-                        .HasColumnType("character varying(50)")
-                        .HasColumnName("language");
 
                     b.Property<int>("LinkTypeId")
                         .HasColumnType("integer")
@@ -1274,10 +1247,10 @@ namespace SeriesScraper.Infrastructure.Migrations
                     b.HasData(
                         new
                         {
-                            Key = "imdb.refresh_interval",
-                            Description = "IMDB refresh schedule: daily, weekly, monthly, or manual",
+                            Key = "ImdbRefreshIntervalHours",
+                            Description = "Interval between IMDB dataset refreshes (hours)",
                             LastModifiedAt = new DateTime(2024, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc),
-                            Value = "weekly"
+                            Value = "24"
                         },
                         new
                         {
@@ -1341,55 +1314,6 @@ namespace SeriesScraper.Infrastructure.Migrations
                             Description = "Memory ceiling for bulk IMDB imports",
                             LastModifiedAt = new DateTime(2024, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc),
                             Value = "256"
-                        },
-                        new
-                        {
-                            Key = "ForumRefreshIntervalHours",
-                            Description = "Interval between forum structure refreshes (hours)",
-                            LastModifiedAt = new DateTime(2024, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc),
-                            Value = "24"
-                        },
-                        new
-                        {
-                            Key = "scrape.request_delay",
-                            Description = "Delay between scrape requests in milliseconds",
-                            LastModifiedAt = new DateTime(2024, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc),
-                            Value = "2000"
-                        },
-                        new
-                        {
-                            Key = "results.page_size",
-                            Description = "Number of results displayed per page",
-                            LastModifiedAt = new DateTime(2024, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc),
-                            Value = "25"
-                        },
-                        new
-                        {
-                            Key = "forum.default_encoding",
-                            Description = "Default character encoding for forum pages",
-                            LastModifiedAt = new DateTime(2024, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc),
-                            Value = "windows-1250"
-                        },
-                        new
-                        {
-                            Key = "language.filter",
-                            Description = "Language filter for results (all = no filter)",
-                            LastModifiedAt = new DateTime(2024, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc),
-                            Value = "all"
-                        },
-                        new
-                        {
-                            Key = "imdb.refresh_interval",
-                            Description = "Interval between IMDB dataset refreshes (hours, 168 = 7 days)",
-                            LastModifiedAt = new DateTime(2024, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc),
-                            Value = "168"
-                        },
-                        new
-                        {
-                            Key = "quality.patterns",
-                            Description = "Quality token patterns (pre-seeded via quality_patterns table)",
-                            LastModifiedAt = new DateTime(2024, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc),
-                            Value = ""
                         });
                 });
 

--- a/src/SeriesScraper.Infrastructure/Migrations/20260403164053_AddScrapeRunType.cs
+++ b/src/SeriesScraper.Infrastructure/Migrations/20260403164053_AddScrapeRunType.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SeriesScraper.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddScrapeRunType : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "run_type",
+                table: "scrape_runs",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: false,
+                defaultValue: "Search");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "run_type",
+                table: "scrape_runs");
+        }
+    }
+}

--- a/src/SeriesScraper.Web/Pages/Results.razor
+++ b/src/SeriesScraper.Web/Pages/Results.razor
@@ -1,10 +1,60 @@
 @page "/results"
 @using SeriesScraper.Domain.Interfaces
 @inject IResultsService ResultsService
+@inject IScrapeRunService ScrapeRunService
+@inject IForumCrudService ForumCrudService
 
 <PageTitle>Scrape Results</PageTitle>
 
 <h3>Scrape Results</h3>
+
+<!-- Scrape Thread by URL -->
+<div class="card mb-3">
+    <div class="card-body">
+        <h6 class="card-title">Scrape thread by URL</h6>
+        <div class="row g-2 align-items-end">
+            <div class="col-md-3">
+                <label class="form-label">Forum</label>
+                <select class="form-select form-select-sm" @bind="_selectedForumId">
+                    <option value="0">— Select forum —</option>
+                    @if (_forums is not null)
+                    {
+                        @foreach (var f in _forums)
+                        {
+                            <option value="@f.ForumId">@f.Name</option>
+                        }
+                    }
+                </select>
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Thread URL</label>
+                <input type="url" class="form-control form-control-sm" @bind="_threadUrl"
+                       placeholder="http://www.warforum.xyz/viewtopic.php?t=123456" />
+            </div>
+            <div class="col-md-2">
+                <button class="btn btn-success btn-sm w-100" @onclick="ScrapeThreadByUrl"
+                        disabled="@_scrapeSubmitting">
+                    @if (_scrapeSubmitting)
+                    {
+                        <span class="spinner-border spinner-border-sm" role="status"></span>
+                    }
+                    else
+                    {
+                        <text>Scrape</text>
+                    }
+                </button>
+            </div>
+        </div>
+        @if (!string.IsNullOrEmpty(_scrapeError))
+        {
+            <div class="alert alert-danger mt-2 mb-0 py-1">@_scrapeError</div>
+        }
+        @if (!string.IsNullOrEmpty(_scrapeSuccess))
+        {
+            <div class="alert alert-success mt-2 mb-0 py-1">@_scrapeSuccess</div>
+        }
+    </div>
+</div>
 
 <!-- Filters -->
 <div class="card mb-3">
@@ -251,6 +301,14 @@ else
     private ResultDetailDto? _detail;
     private bool _loading = true;
 
+    // Scrape-by-URL state
+    private IReadOnlyList<ForumDto>? _forums;
+    private int _selectedForumId;
+    private string? _threadUrl;
+    private bool _scrapeSubmitting;
+    private string? _scrapeError;
+    private string? _scrapeSuccess;
+
     // Filter state
     private string? TitleSearch;
     private string? ContentTypeFilter;
@@ -271,7 +329,52 @@ else
 
     protected override async Task OnInitializedAsync()
     {
+        _forums = await ForumCrudService.GetAllForumsAsync();
         await LoadResultsAsync();
+    }
+
+    private async Task ScrapeThreadByUrl()
+    {
+        _scrapeError = null;
+        _scrapeSuccess = null;
+
+        if (_selectedForumId <= 0)
+        {
+            _scrapeError = "Please select a forum.";
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(_threadUrl))
+        {
+            _scrapeError = "Please enter a thread URL.";
+            return;
+        }
+
+        _scrapeSubmitting = true;
+        StateHasChanged();
+
+        try
+        {
+            var run = await ScrapeRunService.ScrapeByUrlAsync(_threadUrl, _selectedForumId);
+            _scrapeSuccess = $"Scrape run #{run.RunId} started.";
+            _threadUrl = null;
+
+            // Refresh results after a short delay to show the new run
+            await Task.Delay(500);
+            await LoadResultsAsync();
+        }
+        catch (ArgumentException ex)
+        {
+            _scrapeError = ex.Message;
+        }
+        catch (InvalidOperationException ex)
+        {
+            _scrapeError = ex.Message;
+        }
+        finally
+        {
+            _scrapeSubmitting = false;
+        }
     }
 
     private async Task LoadResultsAsync()

--- a/tests/SeriesScraper.Application.Tests/Services/ScrapeRunServiceTests.cs
+++ b/tests/SeriesScraper.Application.Tests/Services/ScrapeRunServiceTests.cs
@@ -15,6 +15,8 @@ public class ScrapeRunServiceTests
     private readonly IScrapeRunRepository _repository;
     private readonly IScrapingJobQueue _jobQueue;
     private readonly IScrapeOrchestrator _orchestrator;
+    private readonly IForumRepository _forumRepository;
+    private readonly IUrlValidator _urlValidator;
     private readonly ILogger<ScrapeRunService> _logger;
     private readonly ScrapeRunService _sut;
 
@@ -23,8 +25,10 @@ public class ScrapeRunServiceTests
         _repository = Substitute.For<IScrapeRunRepository>();
         _jobQueue = Substitute.For<IScrapingJobQueue>();
         _orchestrator = Substitute.For<IScrapeOrchestrator>();
+        _forumRepository = Substitute.For<IForumRepository>();
+        _urlValidator = Substitute.For<IUrlValidator>();
         _logger = Substitute.For<ILogger<ScrapeRunService>>();
-        _sut = new ScrapeRunService(_repository, _jobQueue, _orchestrator, _logger);
+        _sut = new ScrapeRunService(_repository, _jobQueue, _orchestrator, _forumRepository, _urlValidator, _logger);
     }
 
     [Fact]
@@ -212,5 +216,140 @@ public class ScrapeRunServiceTests
         await _sut.CancelRunAsync(runId: 999);
 
         _jobQueue.Received(1).CancelRun(999);
+    }
+
+    // --- ScrapeByUrlAsync ---
+
+    private void SetupForumAndValidator(string baseUrl = "http://www.warforum.xyz")
+    {
+        var forum = new Forum
+        {
+            ForumId = 1,
+            Name = "TestForum",
+            BaseUrl = baseUrl,
+            Username = "user",
+            CredentialKey = "FORUM_PASS"
+        };
+        _forumRepository.GetByIdAsync(1, Arg.Any<CancellationToken>()).Returns(forum);
+        _urlValidator.IsUrlSafe(Arg.Any<string>(), out Arg.Any<string?>()).Returns(true);
+        _repository.CreateAsync(Arg.Any<ScrapeRun>(), Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                var run = ci.Arg<ScrapeRun>();
+                run.RunId = 50;
+                return run;
+            });
+    }
+
+    [Fact]
+    public async Task ScrapeByUrlAsync_ValidUrl_CreatesRunAndEnqueues()
+    {
+        SetupForumAndValidator();
+        var url = "http://www.warforum.xyz/viewtopic.php?t=123456";
+
+        var result = await _sut.ScrapeByUrlAsync(url, forumId: 1);
+
+        result.RunId.Should().Be(50);
+        result.RunType.Should().Be(ScrapeRunType.SingleThread);
+        result.Status.Should().Be(ScrapeRunStatus.Pending);
+        await _jobQueue.Received(1).EnqueueAsync(
+            Arg.Is<ScrapeJob>(j => j.RunId == 50 && j.ForumId == 1
+                && j.PostUrls != null && j.PostUrls.Count == 1 && j.PostUrls[0] == url),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task ScrapeByUrlAsync_NullOrEmptyUrl_Throws(string? url)
+    {
+        var act = () => _sut.ScrapeByUrlAsync(url!, forumId: 1);
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithParameterName("threadUrl");
+    }
+
+    [Fact]
+    public async Task ScrapeByUrlAsync_SsrfBlocked_Throws()
+    {
+        _urlValidator.IsUrlSafe(Arg.Any<string>(), out Arg.Any<string?>())
+            .Returns(ci =>
+            {
+                ci[1] = "IP address is in a blocked range.";
+                return false;
+            });
+
+        var act = () => _sut.ScrapeByUrlAsync("http://127.0.0.1/viewtopic.php?t=1", forumId: 1);
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithParameterName("threadUrl")
+            .WithMessage("*blocked*");
+    }
+
+    [Theory]
+    [InlineData("http://www.warforum.xyz/index.php")]
+    [InlineData("http://www.warforum.xyz/forum/thread/123")]
+    [InlineData("http://www.warforum.xyz/")]
+    public async Task ScrapeByUrlAsync_NotViewtopicUrl_Throws(string url)
+    {
+        _urlValidator.IsUrlSafe(Arg.Any<string>(), out Arg.Any<string?>()).Returns(true);
+
+        var act = () => _sut.ScrapeByUrlAsync(url, forumId: 1);
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithParameterName("threadUrl")
+            .WithMessage("*viewtopic.php*");
+    }
+
+    [Fact]
+    public async Task ScrapeByUrlAsync_ForumNotFound_Throws()
+    {
+        _urlValidator.IsUrlSafe(Arg.Any<string>(), out Arg.Any<string?>()).Returns(true);
+        _forumRepository.GetByIdAsync(99, Arg.Any<CancellationToken>()).Returns((Forum?)null);
+
+        var act = () => _sut.ScrapeByUrlAsync(
+            "http://www.warforum.xyz/viewtopic.php?t=1", forumId: 99);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*Forum 99 not found*");
+    }
+
+    [Fact]
+    public async Task ScrapeByUrlAsync_HostMismatch_Throws()
+    {
+        SetupForumAndValidator("http://www.warforum.xyz");
+
+        var act = () => _sut.ScrapeByUrlAsync(
+            "http://www.evilforum.com/viewtopic.php?t=1", forumId: 1);
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithParameterName("threadUrl")
+            .WithMessage("*does not match*");
+    }
+
+    [Fact]
+    public async Task ScrapeByUrlAsync_InvalidAbsoluteUrl_Throws()
+    {
+        _urlValidator.IsUrlSafe(Arg.Any<string>(), out Arg.Any<string?>()).Returns(true);
+
+        var act = () => _sut.ScrapeByUrlAsync("not-a-url", forumId: 1);
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithParameterName("threadUrl");
+    }
+
+    [Fact]
+    public async Task ScrapeByUrlAsync_ViewtopicInSubpath_Accepted()
+    {
+        SetupForumAndValidator("http://www.warforum.xyz");
+        var url = "http://www.warforum.xyz/forum/viewtopic.php?t=999";
+
+        var result = await _sut.ScrapeByUrlAsync(url, forumId: 1);
+
+        result.RunId.Should().Be(50);
+        await _jobQueue.Received(1).EnqueueAsync(
+            Arg.Is<ScrapeJob>(j => j.PostUrls != null && j.PostUrls[0] == url),
+            Arg.Any<CancellationToken>());
     }
 }

--- a/tests/SeriesScraper.Web.Tests/Pages/ManualThreadUrlTests.cs
+++ b/tests/SeriesScraper.Web.Tests/Pages/ManualThreadUrlTests.cs
@@ -1,0 +1,170 @@
+using Bunit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using SeriesScraper.Domain.Entities;
+using SeriesScraper.Domain.Interfaces;
+using SeriesScraper.Web.Pages;
+
+namespace SeriesScraper.Web.Tests.Pages;
+
+/// <summary>
+/// bUnit tests for Results.razor ScrapeThreadByUrl() method (AC5 of issue #104).
+/// Covers the 6 scenarios required for ≥90% coverage on that path.
+/// </summary>
+public class ManualThreadUrlTests : TestContext
+{
+    private readonly IScrapeRunService _scrapeRunService;
+    private readonly IForumCrudService _forumCrudService;
+    private readonly IResultsService _resultsService;
+
+    private static readonly IReadOnlyList<ForumDto> TestForums =
+    [
+        new ForumDto
+        {
+            ForumId = 1,
+            Name = "Test Forum",
+            BaseUrl = "http://forum.example.com",
+            Username = "user",
+            CredentialKey = "key"
+        }
+    ];
+
+    private static readonly PagedResult<ResultSummaryDto> EmptyPaged = new()
+    {
+        Items = [],
+        TotalCount = 0,
+        Page = 1,
+        PageSize = 20
+    };
+
+    public ManualThreadUrlTests()
+    {
+        _scrapeRunService = Substitute.For<IScrapeRunService>();
+        _forumCrudService = Substitute.For<IForumCrudService>();
+        _resultsService = Substitute.For<IResultsService>();
+
+        _forumCrudService
+            .GetAllForumsAsync(Arg.Any<CancellationToken>())
+            .Returns(TestForums);
+
+        _resultsService
+            .GetResultsAsync(
+                Arg.Any<ResultFilterDto>(), Arg.Any<int>(), Arg.Any<int>(),
+                Arg.Any<string?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(EmptyPaged);
+
+        Services.AddSingleton(_scrapeRunService);
+        Services.AddSingleton(_forumCrudService);
+        Services.AddSingleton(_resultsService);
+    }
+
+    // Scenario 1: no forum selected → error shown
+    [Fact]
+    public void ScrapeThread_NoForumSelected_ShowsForumError()
+    {
+        var cut = RenderComponent<Results>();
+
+        // Forum select defaults to 0 — click Scrape without selecting
+        cut.Find("button.btn-success").Click();
+
+        cut.Find(".alert-danger").TextContent.Should().Contain("Please select a forum.");
+    }
+
+    // Scenario 2: empty URL → error shown
+    [Fact]
+    public void ScrapeThread_EmptyUrl_ShowsUrlError()
+    {
+        var cut = RenderComponent<Results>();
+
+        // Select a valid forum (forum select is the first select on the page)
+        cut.FindAll("select")[0].Change("1");
+
+        // URL field left empty — click Scrape
+        cut.Find("button.btn-success").Click();
+
+        cut.Find(".alert-danger").TextContent.Should().Contain("Please enter a thread URL.");
+    }
+
+    // Scenario 3: ArgumentException from service → displayed as error, no crash
+    [Fact]
+    public async Task ScrapeThread_ServiceThrowsArgumentException_ShowsErrorMessage()
+    {
+        _scrapeRunService
+            .ScrapeByUrlAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<ScrapeRun>(new ArgumentException("Invalid forum URL format.")));
+
+        var cut = RenderComponent<Results>();
+
+        cut.FindAll("select")[0].Change("1");
+        cut.Find("input[type=url]").Change("http://forum.example.com/viewtopic.php?t=1");
+
+        await cut.InvokeAsync(() => cut.Find("button.btn-success").Click());
+
+        cut.Find(".alert-danger").TextContent.Should().Contain("Invalid forum URL format.");
+    }
+
+    // Scenario 4: InvalidOperationException from service → displayed as error
+    [Fact]
+    public async Task ScrapeThread_ServiceThrowsInvalidOperationException_ShowsErrorMessage()
+    {
+        _scrapeRunService
+            .ScrapeByUrlAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<ScrapeRun>(new InvalidOperationException("Scraper is not available.")));
+
+        var cut = RenderComponent<Results>();
+
+        cut.FindAll("select")[0].Change("1");
+        cut.Find("input[type=url]").Change("http://forum.example.com/viewtopic.php?t=2");
+
+        await cut.InvokeAsync(() => cut.Find("button.btn-success").Click());
+
+        cut.Find(".alert-danger").TextContent.Should().Contain("Scraper is not available.");
+    }
+
+    // Scenario 5: valid submission → success message shown, URL field cleared
+    [Fact]
+    public async Task ScrapeThread_ValidSubmission_ShowsSuccessAndClearsUrl()
+    {
+        _scrapeRunService
+            .ScrapeByUrlAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new ScrapeRun { RunId = 42 });
+
+        var cut = RenderComponent<Results>();
+
+        cut.FindAll("select")[0].Change("1");
+        cut.Find("input[type=url]").Change("http://forum.example.com/viewtopic.php?t=99");
+
+        await cut.InvokeAsync(() => cut.Find("button.btn-success").Click());
+
+        cut.Find(".alert-success").TextContent.Should().Contain("Scrape run #42 started.");
+        (cut.Find("input[type=url]").GetAttribute("value") ?? string.Empty).Should().BeEmpty();
+    }
+
+    // Scenario 6: button disabled while submitting
+    [Fact]
+    public async Task ScrapeThread_WhileSubmitting_ButtonIsDisabled()
+    {
+        var tcs = new TaskCompletionSource<ScrapeRun>();
+        _scrapeRunService
+            .ScrapeByUrlAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(tcs.Task);
+
+        var cut = RenderComponent<Results>();
+
+        cut.FindAll("select")[0].Change("1");
+        cut.Find("input[type=url]").Change("http://forum.example.com/viewtopic.php?t=99");
+
+        // Fire click but do not await — the handler suspends at ScrapeByUrlAsync (TCS)
+        // leaving _scrapeSubmitting = true
+        _ = cut.InvokeAsync(() => cut.Find("button.btn-success").Click());
+
+        cut.WaitForAssertion(
+            () => cut.Find("button.btn-success").HasAttribute("disabled").Should().BeTrue(),
+            timeout: TimeSpan.FromSeconds(2));
+
+        // Cleanup: cancel the pending task so no background work leaks
+        tcs.SetCanceled();
+        await Task.Delay(50);
+    }
+}

--- a/tests/SeriesScraper.Web.Tests/SeriesScraper.Web.Tests.csproj
+++ b/tests/SeriesScraper.Web.Tests/SeriesScraper.Web.Tests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="bunit" Version="1.28.9" />
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
     <PackageReference Include="FluentAssertions" Version="6.12.*" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.*" />


### PR DESCRIPTION
Closes #104

## Summary of Changes

Adds the ability to scrape a single forum thread by pasting its URL directly, bypassing the search flow.

### Domain Layer
- **New enum**: \ScrapeRunType\ (Search, SingleThread) in \Domain/Enums/ScrapeRunType.cs\
- **Updated entity**: \ScrapeRun.RunType\ property to track how a run was initiated
- **Updated interface**: \IScrapeRunService.ScrapeByUrlAsync(string threadUrl, int forumId)\

### Application Layer
- **\ScrapeRunService.ScrapeByUrlAsync\**: Validates URL (SSRF via \IUrlValidator\, viewtopic.php check, forum base URL host match), creates a SingleThread run, enqueues a \ScrapeJob\ with the single URL as \PostUrls\

### Infrastructure Layer
- **EF migration**: Adds \un_type\ column (varchar(50), default 'Search') to \scrape_runs\ table
- **ScrapeRunConfiguration**: Maps \RunType\ with string conversion

### Web Layer
- **Results.razor**: Added 'Scrape thread by URL' card with forum dropdown, URL input, Scrape button, validation error/success feedback

### Tests
- 8 new unit tests for \ScrapeByUrlAsync\:
  - Valid URL creates run + enqueues job
  - Null/empty/whitespace URL throws
  - SSRF-blocked URL throws
  - Non-viewtopic URL throws
  - Forum not found throws
  - Host mismatch throws
  - Invalid absolute URL throws
  - viewtopic in subpath accepted
- All 526 tests pass

### Testing Notes
- URL validation reuses existing \IUrlValidator\ (SSRF guard) + additional forum base URL matching
- No search step — goes directly to post extraction via existing \ScrapeOrchestrator.ExecuteAsync\
