### PR TITLE
feat(#103): Watchlist in-app notifications when watched items found during scrape

### DIFF
--- a/src/SeriesScraper.Application/Services/DashboardService.cs
+++ b/src/SeriesScraper.Application/Services/DashboardService.cs
@@ -16,6 +16,7 @@ public class DashboardService : IDashboardService
     private readonly IWatchlistService _watchlistService;
     private readonly IDatabaseStatsProvider _statsProvider;
     private readonly IImdbImportTrigger _importTrigger;
+    private readonly IWatchlistNotificationRepository _notificationRepository;
     private readonly ILogger<DashboardService> _logger;
 
     public DashboardService(
@@ -26,6 +27,7 @@ public class DashboardService : IDashboardService
         IWatchlistService watchlistService,
         IDatabaseStatsProvider statsProvider,
         IImdbImportTrigger importTrigger,
+        IWatchlistNotificationRepository notificationRepository,
         ILogger<DashboardService> logger)
     {
         _forumRepository = forumRepository;
@@ -35,6 +37,7 @@ public class DashboardService : IDashboardService
         _watchlistService = watchlistService;
         _statsProvider = statsProvider;
         _importTrigger = importTrigger;
+        _notificationRepository = notificationRepository ?? throw new ArgumentNullException(nameof(notificationRepository));
         _logger = logger;
     }
 
@@ -47,12 +50,15 @@ public class DashboardService : IDashboardService
         var activeRuns = await GetActiveRunsAsync(ct);
         var watchlist = await GetWatchlistSummaryAsync(ct);
 
+        var unreadNotifications = await _notificationRepository.GetUnreadCountAsync(ct);
+
         return new DashboardDto
         {
             Forums = forums,
             ImdbDataset = imdb,
             ActiveRuns = activeRuns,
-            Watchlist = watchlist
+            Watchlist = watchlist,
+            UnreadNotificationCount = unreadNotifications
         };
     }
 

--- a/src/SeriesScraper.Application/Services/ScrapeOrchestrator.cs
+++ b/src/SeriesScraper.Application/Services/ScrapeOrchestrator.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using SeriesScraper.Application.Utilities;
 using SeriesScraper.Domain.Entities;
 using SeriesScraper.Domain.Enums;
 using SeriesScraper.Domain.Interfaces;
@@ -208,7 +209,7 @@ public class ScrapeOrchestrator : IScrapeOrchestrator
         try
         {
             // Extract a potential title from the post URL path
-            var title = ExtractTitleFromUrl(postUrl);
+            var title = UrlTitleExtractor.ExtractFrom(postUrl);
             if (!string.IsNullOrWhiteSpace(title))
             {
                 var match = await _matchingService.FindBestMatchAsync(title, cancellationToken: ct);
@@ -226,25 +227,5 @@ public class ScrapeOrchestrator : IScrapeOrchestrator
         }
     }
 
-    internal static string? ExtractTitleFromUrl(string url)
-    {
-        try
-        {
-            var uri = new Uri(url);
-            var lastSegment = uri.Segments.LastOrDefault()?.Trim('/');
-            if (string.IsNullOrWhiteSpace(lastSegment))
-                return null;
-
-            // Replace common URL separators with spaces
-            return lastSegment
-                .Replace('-', ' ')
-                .Replace('_', ' ')
-                .Replace('.', ' ')
-                .Trim();
-        }
-        catch
-        {
-            return null;
-        }
-    }
 }
+

--- a/src/SeriesScraper.Application/Services/ScrapeOrchestrator.cs
+++ b/src/SeriesScraper.Application/Services/ScrapeOrchestrator.cs
@@ -20,6 +20,7 @@ public class ScrapeOrchestrator : IScrapeOrchestrator
     private readonly IScrapeRunRepository _runRepository;
     private readonly ILinkRepository _linkRepository;
     private readonly IImdbMatchingService _matchingService;
+    private readonly IWatchlistNotificationService _notificationService;
     private readonly ILogger<ScrapeOrchestrator> _logger;
 
     public ScrapeOrchestrator(
@@ -29,6 +30,7 @@ public class ScrapeOrchestrator : IScrapeOrchestrator
         IScrapeRunRepository runRepository,
         ILinkRepository linkRepository,
         IImdbMatchingService matchingService,
+        IWatchlistNotificationService notificationService,
         ILogger<ScrapeOrchestrator> logger)
     {
         _postScraper = postScraper ?? throw new ArgumentNullException(nameof(postScraper));
@@ -37,6 +39,7 @@ public class ScrapeOrchestrator : IScrapeOrchestrator
         _runRepository = runRepository ?? throw new ArgumentNullException(nameof(runRepository));
         _linkRepository = linkRepository ?? throw new ArgumentNullException(nameof(linkRepository));
         _matchingService = matchingService ?? throw new ArgumentNullException(nameof(matchingService));
+        _notificationService = notificationService ?? throw new ArgumentNullException(nameof(notificationService));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -149,6 +152,16 @@ public class ScrapeOrchestrator : IScrapeOrchestrator
         _logger.LogInformation(
             "Run {RunId} processing complete: {Succeeded} succeeded, {Failed} failed out of {Total}",
             job.RunId, succeeded, failed, urlsToProcess.Count);
+
+        // Cross-check new links against watchlist and create notifications
+        try
+        {
+            await _notificationService.CreateNotificationsForRunAsync(job.RunId, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to create watchlist notifications for run {RunId}, continuing", job.RunId);
+        }
     }
 
     private async Task<IReadOnlyList<string>> ResolvePostUrlsAsync(

--- a/src/SeriesScraper.Application/Services/WatchlistNotificationService.cs
+++ b/src/SeriesScraper.Application/Services/WatchlistNotificationService.cs
@@ -1,0 +1,163 @@
+using Microsoft.Extensions.Logging;
+using SeriesScraper.Domain.Entities;
+using SeriesScraper.Domain.Interfaces;
+
+namespace SeriesScraper.Application.Services;
+
+public class WatchlistNotificationService : IWatchlistNotificationService
+{
+    private readonly IWatchlistNotificationRepository _notificationRepository;
+    private readonly IWatchlistRepository _watchlistRepository;
+    private readonly ILinkRepository _linkRepository;
+    private readonly ILogger<WatchlistNotificationService> _logger;
+
+    public WatchlistNotificationService(
+        IWatchlistNotificationRepository notificationRepository,
+        IWatchlistRepository watchlistRepository,
+        ILinkRepository linkRepository,
+        ILogger<WatchlistNotificationService> logger)
+    {
+        _notificationRepository = notificationRepository ?? throw new ArgumentNullException(nameof(notificationRepository));
+        _watchlistRepository = watchlistRepository ?? throw new ArgumentNullException(nameof(watchlistRepository));
+        _linkRepository = linkRepository ?? throw new ArgumentNullException(nameof(linkRepository));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task CreateNotificationsForRunAsync(int runId, CancellationToken ct = default)
+    {
+        var watchlistItems = await _watchlistRepository.GetAllAsync(activeOnly: true, ct);
+        if (watchlistItems.Count == 0)
+        {
+            _logger.LogDebug("No active watchlist items, skipping notification check for run {RunId}", runId);
+            return;
+        }
+
+        var runLinks = await _linkRepository.GetCurrentByRunIdAsync(runId, ct);
+        if (runLinks.Count == 0)
+        {
+            _logger.LogDebug("No links found for run {RunId}, skipping notification check", runId);
+            return;
+        }
+
+        // Build a lookup from MediaTitleId to watchlist items that want notifications
+        var watchlistByTitle = watchlistItems
+            .Where(w => w.MediaTitleId.HasValue && w.NotificationPreference != Domain.Enums.NotificationPreference.None)
+            .GroupBy(w => w.CustomTitle.ToUpperInvariant())
+            .ToDictionary(g => g.Key, g => g.ToList());
+
+        // Also index by MediaTitleId for more precise matching
+        var watchlistByMediaId = watchlistItems
+            .Where(w => w.MediaTitleId.HasValue && w.NotificationPreference != Domain.Enums.NotificationPreference.None)
+            .GroupBy(w => w.MediaTitleId!.Value)
+            .ToDictionary(g => g.Key, g => g.ToList());
+
+        // Custom title watchlist items (no MediaTitleId) — match by title substring in PostUrl
+        var customWatchlistItems = watchlistItems
+            .Where(w => !w.MediaTitleId.HasValue && w.NotificationPreference != Domain.Enums.NotificationPreference.None)
+            .ToList();
+
+        var notifications = new List<WatchlistNotification>();
+
+        foreach (var link in runLinks)
+        {
+            // Try matching via post URL title extraction
+            var extractedTitle = ScrapeOrchestrator.ExtractTitleFromUrl(link.PostUrl);
+            if (extractedTitle is null)
+                continue;
+
+            var normalizedTitle = extractedTitle.ToUpperInvariant();
+
+            // Match against watchlist items by title similarity
+            foreach (var (titleKey, items) in watchlistByTitle)
+            {
+                if (normalizedTitle.Contains(titleKey) || titleKey.Contains(normalizedTitle))
+                {
+                    foreach (var item in items)
+                    {
+                        notifications.Add(new WatchlistNotification
+                        {
+                            WatchlistItemId = item.WatchlistItemId,
+                            LinkId = link.LinkId,
+                            CreatedAt = DateTime.UtcNow,
+                            IsRead = false
+                        });
+                    }
+                }
+            }
+
+            // Match custom title watchlist items by substring match in PostUrl
+            foreach (var item in customWatchlistItems)
+            {
+                var customNorm = item.CustomTitle.ToUpperInvariant();
+                if (normalizedTitle.Contains(customNorm) || customNorm.Contains(normalizedTitle))
+                {
+                    notifications.Add(new WatchlistNotification
+                    {
+                        WatchlistItemId = item.WatchlistItemId,
+                        LinkId = link.LinkId,
+                        CreatedAt = DateTime.UtcNow,
+                        IsRead = false
+                    });
+                }
+            }
+        }
+
+        // Deduplicate by (WatchlistItemId, LinkId)
+        var uniqueNotifications = notifications
+            .GroupBy(n => (n.WatchlistItemId, n.LinkId))
+            .Select(g => g.First())
+            .ToList();
+
+        if (uniqueNotifications.Count > 0)
+        {
+            await _notificationRepository.AddRangeAsync(uniqueNotifications, ct);
+            _logger.LogInformation(
+                "Created {Count} watchlist notifications for run {RunId}",
+                uniqueNotifications.Count, runId);
+        }
+        else
+        {
+            _logger.LogDebug("No watchlist matches found for run {RunId}", runId);
+        }
+    }
+
+    public async Task<IReadOnlyList<WatchlistNotificationDto>> GetAllNotificationsAsync(CancellationToken ct = default)
+    {
+        var notifications = await _notificationRepository.GetAllAsync(ct);
+        return notifications.Select(MapToDto).ToList();
+    }
+
+    public async Task<IReadOnlyList<WatchlistNotificationDto>> GetUnreadNotificationsAsync(CancellationToken ct = default)
+    {
+        var notifications = await _notificationRepository.GetUnreadAsync(ct);
+        return notifications.Select(MapToDto).ToList();
+    }
+
+    public async Task<int> GetUnreadCountAsync(CancellationToken ct = default)
+    {
+        return await _notificationRepository.GetUnreadCountAsync(ct);
+    }
+
+    public async Task MarkAsReadAsync(int notificationId, CancellationToken ct = default)
+    {
+        await _notificationRepository.MarkAsReadAsync(notificationId, ct);
+        _logger.LogDebug("Marked notification {NotificationId} as read", notificationId);
+    }
+
+    public async Task MarkAllAsReadAsync(CancellationToken ct = default)
+    {
+        await _notificationRepository.MarkAllAsReadAsync(ct);
+        _logger.LogInformation("Marked all notifications as read");
+    }
+
+    private static WatchlistNotificationDto MapToDto(WatchlistNotification n) => new()
+    {
+        WatchlistNotificationId = n.WatchlistNotificationId,
+        WatchlistItemId = n.WatchlistItemId,
+        WatchlistTitle = n.WatchlistItem?.CustomTitle ?? "Unknown",
+        LinkId = n.LinkId,
+        LinkUrl = n.Link?.Url ?? "",
+        CreatedAt = n.CreatedAt,
+        IsRead = n.IsRead
+    };
+}

--- a/src/SeriesScraper.Application/Services/WatchlistNotificationService.cs
+++ b/src/SeriesScraper.Application/Services/WatchlistNotificationService.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using SeriesScraper.Application.Utilities;
 using SeriesScraper.Domain.Entities;
 using SeriesScraper.Domain.Interfaces;
 
@@ -39,16 +40,10 @@ public class WatchlistNotificationService : IWatchlistNotificationService
             return;
         }
 
-        // Build a lookup from MediaTitleId to watchlist items that want notifications
+        // Build a lookup from CustomTitle (normalized) to watchlist items that want notifications
         var watchlistByTitle = watchlistItems
             .Where(w => w.MediaTitleId.HasValue && w.NotificationPreference != Domain.Enums.NotificationPreference.None)
             .GroupBy(w => w.CustomTitle.ToUpperInvariant())
-            .ToDictionary(g => g.Key, g => g.ToList());
-
-        // Also index by MediaTitleId for more precise matching
-        var watchlistByMediaId = watchlistItems
-            .Where(w => w.MediaTitleId.HasValue && w.NotificationPreference != Domain.Enums.NotificationPreference.None)
-            .GroupBy(w => w.MediaTitleId!.Value)
             .ToDictionary(g => g.Key, g => g.ToList());
 
         // Custom title watchlist items (no MediaTitleId) — match by title substring in PostUrl
@@ -61,7 +56,7 @@ public class WatchlistNotificationService : IWatchlistNotificationService
         foreach (var link in runLinks)
         {
             // Try matching via post URL title extraction
-            var extractedTitle = ScrapeOrchestrator.ExtractTitleFromUrl(link.PostUrl);
+            var extractedTitle = UrlTitleExtractor.ExtractFrom(link.PostUrl);
             if (extractedTitle is null)
                 continue;
 
@@ -157,6 +152,8 @@ public class WatchlistNotificationService : IWatchlistNotificationService
         WatchlistTitle = n.WatchlistItem?.CustomTitle ?? "Unknown",
         LinkId = n.LinkId,
         LinkUrl = n.Link?.Url ?? "",
+        Language = n.Link?.Language,
+        Quality = n.Link?.Quality,
         CreatedAt = n.CreatedAt,
         IsRead = n.IsRead
     };

--- a/src/SeriesScraper.Application/Utilities/UrlTitleExtractor.cs
+++ b/src/SeriesScraper.Application/Utilities/UrlTitleExtractor.cs
@@ -1,0 +1,33 @@
+namespace SeriesScraper.Application.Utilities;
+
+/// <summary>
+/// Shared utility for extracting a human-readable title from a forum post URL.
+/// Used by both ScrapeOrchestrator and WatchlistNotificationService.
+/// </summary>
+internal static class UrlTitleExtractor
+{
+    /// <summary>
+    /// Returns the last URL segment with dashes/underscores/dots replaced by spaces,
+    /// or null if the URL cannot be parsed.
+    /// </summary>
+    internal static string? ExtractFrom(string url)
+    {
+        try
+        {
+            var uri = new Uri(url);
+            var lastSegment = uri.Segments.LastOrDefault()?.Trim('/');
+            if (string.IsNullOrWhiteSpace(lastSegment))
+                return null;
+
+            return lastSegment
+                .Replace('-', ' ')
+                .Replace('_', ' ')
+                .Replace('.', ' ')
+                .Trim();
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/src/SeriesScraper.Domain/Entities/Link.cs
+++ b/src/SeriesScraper.Domain/Entities/Link.cs
@@ -42,6 +42,11 @@ public class Link
     
     public int RunId { get; set; }
     
+    /// <summary>
+    /// Quality descriptor extracted from the post (e.g., "1080p BluRay"). Null = not yet extracted.
+    /// </summary>
+    public string? Quality { get; set; }
+    
     // Navigation properties
     public LinkType LinkType { get; set; } = null!;
     public ScrapeRun Run { get; set; } = null!;

--- a/src/SeriesScraper.Domain/Entities/WatchlistNotification.cs
+++ b/src/SeriesScraper.Domain/Entities/WatchlistNotification.cs
@@ -1,0 +1,14 @@
+namespace SeriesScraper.Domain.Entities;
+
+public class WatchlistNotification
+{
+    public int WatchlistNotificationId { get; set; }
+    public int WatchlistItemId { get; set; }
+    public int LinkId { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public bool IsRead { get; set; }
+
+    // Navigation properties
+    public WatchlistItem WatchlistItem { get; set; } = null!;
+    public Link Link { get; set; } = null!;
+}

--- a/src/SeriesScraper.Domain/Interfaces/IDashboardService.cs
+++ b/src/SeriesScraper.Domain/Interfaces/IDashboardService.cs
@@ -20,6 +20,7 @@ public record DashboardDto
     public ImdbDatasetStatusDto ImdbDataset { get; init; } = new();
     public IReadOnlyList<ActiveRunDto> ActiveRuns { get; init; } = [];
     public WatchlistSummaryDto Watchlist { get; init; } = new();
+    public int UnreadNotificationCount { get; init; }
 }
 
 /// <summary>

--- a/src/SeriesScraper.Domain/Interfaces/IWatchlistNotificationRepository.cs
+++ b/src/SeriesScraper.Domain/Interfaces/IWatchlistNotificationRepository.cs
@@ -1,0 +1,15 @@
+using SeriesScraper.Domain.Entities;
+
+namespace SeriesScraper.Domain.Interfaces;
+
+public interface IWatchlistNotificationRepository
+{
+    Task<WatchlistNotification> AddAsync(WatchlistNotification notification, CancellationToken ct = default);
+    Task AddRangeAsync(IEnumerable<WatchlistNotification> notifications, CancellationToken ct = default);
+    Task<WatchlistNotification?> GetByIdAsync(int notificationId, CancellationToken ct = default);
+    Task<IReadOnlyList<WatchlistNotification>> GetAllAsync(CancellationToken ct = default);
+    Task<IReadOnlyList<WatchlistNotification>> GetUnreadAsync(CancellationToken ct = default);
+    Task<int> GetUnreadCountAsync(CancellationToken ct = default);
+    Task MarkAsReadAsync(int notificationId, CancellationToken ct = default);
+    Task MarkAllAsReadAsync(CancellationToken ct = default);
+}

--- a/src/SeriesScraper.Domain/Interfaces/IWatchlistNotificationService.cs
+++ b/src/SeriesScraper.Domain/Interfaces/IWatchlistNotificationService.cs
@@ -17,6 +17,8 @@ public record WatchlistNotificationDto
     public required string WatchlistTitle { get; init; }
     public int LinkId { get; init; }
     public required string LinkUrl { get; init; }
+    public string? Language { get; init; }
+    public string? Quality { get; init; }
     public DateTime CreatedAt { get; init; }
     public bool IsRead { get; init; }
 }

--- a/src/SeriesScraper.Domain/Interfaces/IWatchlistNotificationService.cs
+++ b/src/SeriesScraper.Domain/Interfaces/IWatchlistNotificationService.cs
@@ -1,0 +1,22 @@
+namespace SeriesScraper.Domain.Interfaces;
+
+public interface IWatchlistNotificationService
+{
+    Task CreateNotificationsForRunAsync(int runId, CancellationToken ct = default);
+    Task<IReadOnlyList<WatchlistNotificationDto>> GetAllNotificationsAsync(CancellationToken ct = default);
+    Task<IReadOnlyList<WatchlistNotificationDto>> GetUnreadNotificationsAsync(CancellationToken ct = default);
+    Task<int> GetUnreadCountAsync(CancellationToken ct = default);
+    Task MarkAsReadAsync(int notificationId, CancellationToken ct = default);
+    Task MarkAllAsReadAsync(CancellationToken ct = default);
+}
+
+public record WatchlistNotificationDto
+{
+    public int WatchlistNotificationId { get; init; }
+    public int WatchlistItemId { get; init; }
+    public required string WatchlistTitle { get; init; }
+    public int LinkId { get; init; }
+    public required string LinkUrl { get; init; }
+    public DateTime CreatedAt { get; init; }
+    public bool IsRead { get; init; }
+}

--- a/src/SeriesScraper.Infrastructure/Data/AppDbContext.cs
+++ b/src/SeriesScraper.Infrastructure/Data/AppDbContext.cs
@@ -41,6 +41,7 @@ public class AppDbContext : DbContext, IDataProtectionKeyContext
     public DbSet<ImdbTitleEpisodeStaging> ImdbTitleEpisodeStaging => Set<ImdbTitleEpisodeStaging>();
     public DbSet<ImdbTitleRatingsStaging> ImdbTitleRatingsStaging => Set<ImdbTitleRatingsStaging>();
     public DbSet<WatchlistItem> WatchlistItems => Set<WatchlistItem>();
+    public DbSet<WatchlistNotification> WatchlistNotifications => Set<WatchlistNotification>();
     
     // DataProtection key storage (IDataProtectionKeyContext)
     public DbSet<DataProtectionKey> DataProtectionKeys { get; set; } = null!;

--- a/src/SeriesScraper.Infrastructure/Data/Configurations/LinkConfiguration.cs
+++ b/src/SeriesScraper.Infrastructure/Data/Configurations/LinkConfiguration.cs
@@ -33,6 +33,9 @@ public class LinkConfiguration : IEntityTypeConfiguration<Link>
         entity.Property(e => e.Language)
             .HasMaxLength(50);
         
+        entity.Property(e => e.Quality)
+            .HasMaxLength(100);
+        
         entity.HasOne(e => e.LinkType)
             .WithMany(lt => lt.Links)
             .HasForeignKey(e => e.LinkTypeId)

--- a/src/SeriesScraper.Infrastructure/Data/Configurations/WatchlistNotificationConfiguration.cs
+++ b/src/SeriesScraper.Infrastructure/Data/Configurations/WatchlistNotificationConfiguration.cs
@@ -1,0 +1,40 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using SeriesScraper.Domain.Entities;
+
+namespace SeriesScraper.Infrastructure.Data.Configurations;
+
+public class WatchlistNotificationConfiguration : IEntityTypeConfiguration<WatchlistNotification>
+{
+    public void Configure(EntityTypeBuilder<WatchlistNotification> entity)
+    {
+        entity.HasKey(e => e.WatchlistNotificationId);
+
+        entity.Property(e => e.CreatedAt)
+            .HasColumnType("timestamp with time zone")
+            .HasDefaultValueSql("CURRENT_TIMESTAMP");
+
+        entity.Property(e => e.IsRead)
+            .HasDefaultValue(false);
+
+        entity.HasOne(e => e.WatchlistItem)
+            .WithMany()
+            .HasForeignKey(e => e.WatchlistItemId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        entity.HasOne(e => e.Link)
+            .WithMany()
+            .HasForeignKey(e => e.LinkId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        entity.HasIndex(e => e.IsRead)
+            .HasDatabaseName("IX_WatchlistNotifications_IsRead");
+
+        entity.HasIndex(e => e.WatchlistItemId)
+            .HasDatabaseName("IX_WatchlistNotifications_WatchlistItemId");
+
+        entity.HasIndex(e => new { e.WatchlistItemId, e.LinkId })
+            .IsUnique()
+            .HasDatabaseName("IX_WatchlistNotifications_WatchlistItemId_LinkId");
+    }
+}

--- a/src/SeriesScraper.Infrastructure/Migrations/20260403170422_AddWatchlistNotifications.Designer.cs
+++ b/src/SeriesScraper.Infrastructure/Migrations/20260403170422_AddWatchlistNotifications.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SeriesScraper.Infrastructure.Data;
@@ -11,9 +12,11 @@ using SeriesScraper.Infrastructure.Data;
 namespace SeriesScraper.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260403170422_AddWatchlistNotifications")]
+    partial class AddWatchlistNotifications
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -21,31 +24,6 @@ namespace SeriesScraper.Infrastructure.Migrations
                 .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
-
-            modelBuilder.Entity("Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.DataProtectionKey", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("integer")
-                        .HasColumnName("id");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
-
-                    b.Property<string>("FriendlyName")
-                        .HasMaxLength(500)
-                        .HasColumnType("character varying(500)")
-                        .HasColumnName("friendly_name");
-
-                    b.Property<string>("Xml")
-                        .IsRequired()
-                        .HasColumnType("text")
-                        .HasColumnName("xml");
-
-                    b.HasKey("Id")
-                        .HasName("pk_data_protection_keys");
-
-                    b.ToTable("data_protection_keys", (string)null);
-                });
 
             modelBuilder.Entity("SeriesScraper.Domain.Entities.ContentType", b =>
                 {
@@ -540,11 +518,6 @@ namespace SeriesScraper.Infrastructure.Migrations
                         .HasColumnType("boolean")
                         .HasDefaultValue(true)
                         .HasColumnName("is_current");
-
-                    b.Property<string>("Language")
-                        .HasMaxLength(50)
-                        .HasColumnType("character varying(50)")
-                        .HasColumnName("language");
 
                     b.Property<int>("LinkTypeId")
                         .HasColumnType("integer")
@@ -1162,14 +1135,6 @@ namespace SeriesScraper.Infrastructure.Migrations
                         .HasDefaultValue(0)
                         .HasColumnName("processed_items");
 
-                    b.Property<string>("RunType")
-                        .IsRequired()
-                        .ValueGeneratedOnAdd()
-                        .HasMaxLength(50)
-                        .HasColumnType("character varying(50)")
-                        .HasDefaultValue("Search")
-                        .HasColumnName("run_type");
-
                     b.Property<DateTime>("StartedAt")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("timestamp with time zone")
@@ -1274,10 +1239,10 @@ namespace SeriesScraper.Infrastructure.Migrations
                     b.HasData(
                         new
                         {
-                            Key = "imdb.refresh_interval",
-                            Description = "IMDB refresh schedule: daily, weekly, monthly, or manual",
+                            Key = "ImdbRefreshIntervalHours",
+                            Description = "Interval between IMDB dataset refreshes (hours)",
                             LastModifiedAt = new DateTime(2024, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc),
-                            Value = "weekly"
+                            Value = "24"
                         },
                         new
                         {
@@ -1341,55 +1306,6 @@ namespace SeriesScraper.Infrastructure.Migrations
                             Description = "Memory ceiling for bulk IMDB imports",
                             LastModifiedAt = new DateTime(2024, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc),
                             Value = "256"
-                        },
-                        new
-                        {
-                            Key = "ForumRefreshIntervalHours",
-                            Description = "Interval between forum structure refreshes (hours)",
-                            LastModifiedAt = new DateTime(2024, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc),
-                            Value = "24"
-                        },
-                        new
-                        {
-                            Key = "scrape.request_delay",
-                            Description = "Delay between scrape requests in milliseconds",
-                            LastModifiedAt = new DateTime(2024, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc),
-                            Value = "2000"
-                        },
-                        new
-                        {
-                            Key = "results.page_size",
-                            Description = "Number of results displayed per page",
-                            LastModifiedAt = new DateTime(2024, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc),
-                            Value = "25"
-                        },
-                        new
-                        {
-                            Key = "forum.default_encoding",
-                            Description = "Default character encoding for forum pages",
-                            LastModifiedAt = new DateTime(2024, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc),
-                            Value = "windows-1250"
-                        },
-                        new
-                        {
-                            Key = "language.filter",
-                            Description = "Language filter for results (all = no filter)",
-                            LastModifiedAt = new DateTime(2024, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc),
-                            Value = "all"
-                        },
-                        new
-                        {
-                            Key = "imdb.refresh_interval",
-                            Description = "Interval between IMDB dataset refreshes (hours, 168 = 7 days)",
-                            LastModifiedAt = new DateTime(2024, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc),
-                            Value = "168"
-                        },
-                        new
-                        {
-                            Key = "quality.patterns",
-                            Description = "Quality token patterns (pre-seeded via quality_patterns table)",
-                            LastModifiedAt = new DateTime(2024, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc),
-                            Value = ""
                         });
                 });
 

--- a/src/SeriesScraper.Infrastructure/Migrations/20260403170422_AddWatchlistNotifications.cs
+++ b/src/SeriesScraper.Infrastructure/Migrations/20260403170422_AddWatchlistNotifications.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace SeriesScraper.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddWatchlistNotifications : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "watchlist_notifications",
+                columns: table => new
+                {
+                    watchlist_notification_id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    watchlist_item_id = table.Column<int>(type: "integer", nullable: false),
+                    link_id = table.Column<int>(type: "integer", nullable: false),
+                    created_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP"),
+                    is_read = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_watchlist_notifications", x => x.watchlist_notification_id);
+                    table.ForeignKey(
+                        name: "fk_watchlist_notifications_links_link_id",
+                        column: x => x.link_id,
+                        principalTable: "links",
+                        principalColumn: "link_id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "fk_watchlist_notifications_watchlist_items_watchlist_item_id",
+                        column: x => x.watchlist_item_id,
+                        principalTable: "watchlist_items",
+                        principalColumn: "watchlist_item_id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_watchlist_notifications_link_id",
+                table: "watchlist_notifications",
+                column: "link_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WatchlistNotifications_IsRead",
+                table: "watchlist_notifications",
+                column: "is_read");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WatchlistNotifications_WatchlistItemId",
+                table: "watchlist_notifications",
+                column: "watchlist_item_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WatchlistNotifications_WatchlistItemId_LinkId",
+                table: "watchlist_notifications",
+                columns: new[] { "watchlist_item_id", "link_id" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "watchlist_notifications");
+        }
+    }
+}

--- a/src/SeriesScraper.Infrastructure/Migrations/20260404101759_AddLinkLanguageQuality.Designer.cs
+++ b/src/SeriesScraper.Infrastructure/Migrations/20260404101759_AddLinkLanguageQuality.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SeriesScraper.Infrastructure.Data;
@@ -11,9 +12,11 @@ using SeriesScraper.Infrastructure.Data;
 namespace SeriesScraper.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260404101759_AddLinkLanguageQuality")]
+    partial class AddLinkLanguageQuality
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -21,31 +24,6 @@ namespace SeriesScraper.Infrastructure.Migrations
                 .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
-
-            modelBuilder.Entity("Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.DataProtectionKey", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("integer")
-                        .HasColumnName("id");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
-
-                    b.Property<string>("FriendlyName")
-                        .HasMaxLength(500)
-                        .HasColumnType("character varying(500)")
-                        .HasColumnName("friendly_name");
-
-                    b.Property<string>("Xml")
-                        .IsRequired()
-                        .HasColumnType("text")
-                        .HasColumnName("xml");
-
-                    b.HasKey("Id")
-                        .HasName("pk_data_protection_keys");
-
-                    b.ToTable("data_protection_keys", (string)null);
-                });
 
             modelBuilder.Entity("SeriesScraper.Domain.Entities.ContentType", b =>
                 {
@@ -1167,14 +1145,6 @@ namespace SeriesScraper.Infrastructure.Migrations
                         .HasDefaultValue(0)
                         .HasColumnName("processed_items");
 
-                    b.Property<string>("RunType")
-                        .IsRequired()
-                        .ValueGeneratedOnAdd()
-                        .HasMaxLength(50)
-                        .HasColumnType("character varying(50)")
-                        .HasDefaultValue("Search")
-                        .HasColumnName("run_type");
-
                     b.Property<DateTime>("StartedAt")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("timestamp with time zone")
@@ -1279,10 +1249,10 @@ namespace SeriesScraper.Infrastructure.Migrations
                     b.HasData(
                         new
                         {
-                            Key = "imdb.refresh_interval",
-                            Description = "IMDB refresh schedule: daily, weekly, monthly, or manual",
+                            Key = "ImdbRefreshIntervalHours",
+                            Description = "Interval between IMDB dataset refreshes (hours)",
                             LastModifiedAt = new DateTime(2024, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc),
-                            Value = "weekly"
+                            Value = "24"
                         },
                         new
                         {
@@ -1346,55 +1316,6 @@ namespace SeriesScraper.Infrastructure.Migrations
                             Description = "Memory ceiling for bulk IMDB imports",
                             LastModifiedAt = new DateTime(2024, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc),
                             Value = "256"
-                        },
-                        new
-                        {
-                            Key = "ForumRefreshIntervalHours",
-                            Description = "Interval between forum structure refreshes (hours)",
-                            LastModifiedAt = new DateTime(2024, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc),
-                            Value = "24"
-                        },
-                        new
-                        {
-                            Key = "scrape.request_delay",
-                            Description = "Delay between scrape requests in milliseconds",
-                            LastModifiedAt = new DateTime(2024, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc),
-                            Value = "2000"
-                        },
-                        new
-                        {
-                            Key = "results.page_size",
-                            Description = "Number of results displayed per page",
-                            LastModifiedAt = new DateTime(2024, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc),
-                            Value = "25"
-                        },
-                        new
-                        {
-                            Key = "forum.default_encoding",
-                            Description = "Default character encoding for forum pages",
-                            LastModifiedAt = new DateTime(2024, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc),
-                            Value = "windows-1250"
-                        },
-                        new
-                        {
-                            Key = "language.filter",
-                            Description = "Language filter for results (all = no filter)",
-                            LastModifiedAt = new DateTime(2024, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc),
-                            Value = "all"
-                        },
-                        new
-                        {
-                            Key = "imdb.refresh_interval",
-                            Description = "Interval between IMDB dataset refreshes (hours, 168 = 7 days)",
-                            LastModifiedAt = new DateTime(2024, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc),
-                            Value = "168"
-                        },
-                        new
-                        {
-                            Key = "quality.patterns",
-                            Description = "Quality token patterns (pre-seeded via quality_patterns table)",
-                            LastModifiedAt = new DateTime(2024, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc),
-                            Value = ""
                         });
                 });
 

--- a/src/SeriesScraper.Infrastructure/Migrations/20260404101759_AddLinkLanguageQuality.cs
+++ b/src/SeriesScraper.Infrastructure/Migrations/20260404101759_AddLinkLanguageQuality.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SeriesScraper.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLinkLanguageQuality : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "quality",
+                table: "links",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "quality",
+                table: "links");
+        }
+    }
+}

--- a/src/SeriesScraper.Infrastructure/Repositories/WatchlistNotificationRepository.cs
+++ b/src/SeriesScraper.Infrastructure/Repositories/WatchlistNotificationRepository.cs
@@ -1,0 +1,79 @@
+using Microsoft.EntityFrameworkCore;
+using SeriesScraper.Domain.Entities;
+using SeriesScraper.Domain.Interfaces;
+using SeriesScraper.Infrastructure.Data;
+
+namespace SeriesScraper.Infrastructure.Repositories;
+
+public class WatchlistNotificationRepository : IWatchlistNotificationRepository
+{
+    private readonly AppDbContext _context;
+
+    public WatchlistNotificationRepository(AppDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<WatchlistNotification> AddAsync(WatchlistNotification notification, CancellationToken ct = default)
+    {
+        _context.WatchlistNotifications.Add(notification);
+        await _context.SaveChangesAsync(ct);
+        return notification;
+    }
+
+    public async Task AddRangeAsync(IEnumerable<WatchlistNotification> notifications, CancellationToken ct = default)
+    {
+        _context.WatchlistNotifications.AddRange(notifications);
+        await _context.SaveChangesAsync(ct);
+    }
+
+    public async Task<WatchlistNotification?> GetByIdAsync(int notificationId, CancellationToken ct = default)
+    {
+        return await _context.WatchlistNotifications
+            .Include(n => n.WatchlistItem)
+            .Include(n => n.Link)
+            .FirstOrDefaultAsync(n => n.WatchlistNotificationId == notificationId, ct);
+    }
+
+    public async Task<IReadOnlyList<WatchlistNotification>> GetAllAsync(CancellationToken ct = default)
+    {
+        return await _context.WatchlistNotifications
+            .Include(n => n.WatchlistItem)
+            .Include(n => n.Link)
+            .OrderByDescending(n => n.CreatedAt)
+            .ToListAsync(ct);
+    }
+
+    public async Task<IReadOnlyList<WatchlistNotification>> GetUnreadAsync(CancellationToken ct = default)
+    {
+        return await _context.WatchlistNotifications
+            .Include(n => n.WatchlistItem)
+            .Include(n => n.Link)
+            .Where(n => !n.IsRead)
+            .OrderByDescending(n => n.CreatedAt)
+            .ToListAsync(ct);
+    }
+
+    public async Task<int> GetUnreadCountAsync(CancellationToken ct = default)
+    {
+        return await _context.WatchlistNotifications
+            .CountAsync(n => !n.IsRead, ct);
+    }
+
+    public async Task MarkAsReadAsync(int notificationId, CancellationToken ct = default)
+    {
+        var notification = await _context.WatchlistNotifications.FindAsync(new object[] { notificationId }, ct);
+        if (notification is not null)
+        {
+            notification.IsRead = true;
+            await _context.SaveChangesAsync(ct);
+        }
+    }
+
+    public async Task MarkAllAsReadAsync(CancellationToken ct = default)
+    {
+        await _context.WatchlistNotifications
+            .Where(n => !n.IsRead)
+            .ExecuteUpdateAsync(s => s.SetProperty(n => n.IsRead, true), ct);
+    }
+}

--- a/src/SeriesScraper.Web/Pages/Index.razor
+++ b/src/SeriesScraper.Web/Pages/Index.razor
@@ -145,6 +145,10 @@
     <div class="card mb-3">
         <div class="card-header">
             <span class="oi oi-star" aria-hidden="true"></span> Watchlist Notifications
+            @if (_dashboard.UnreadNotificationCount > 0)
+            {
+                <span class="badge bg-danger ms-2">@_dashboard.UnreadNotificationCount unread</span>
+            }
         </div>
         <div class="card-body">
             <div class="d-flex justify-content-between align-items-center">
@@ -162,6 +166,7 @@
                 <div>
                     <span class="me-3">@_dashboard.Watchlist.TotalWatchlistItems items tracked</span>
                     <a href="watchlist" class="btn btn-outline-primary btn-sm">View Watchlist</a>
+                    <a href="notifications" class="btn btn-outline-secondary btn-sm ms-1">Notifications</a>
                 </div>
             </div>
         </div>

--- a/src/SeriesScraper.Web/Pages/Notifications.razor
+++ b/src/SeriesScraper.Web/Pages/Notifications.razor
@@ -33,6 +33,8 @@ else
             <thead class="table-dark">
                 <tr>
                     <th>Title</th>
+                    <th>Language</th>
+                    <th>Quality</th>
                     <th>Link</th>
                     <th>Found At</th>
                     <th>Status</th>
@@ -44,6 +46,8 @@ else
                 {
                     <tr class="@(n.IsRead ? "text-muted" : "fw-bold")">
                         <td>@n.WatchlistTitle</td>
+                        <td>@(n.Language ?? "—")</td>
+                        <td>@(n.Quality ?? "—")</td>
                         <td>
                             <a href="@n.LinkUrl" target="_blank" rel="noopener noreferrer" class="text-truncate d-inline-block" style="max-width: 400px;">
                                 @n.LinkUrl

--- a/src/SeriesScraper.Web/Pages/Notifications.razor
+++ b/src/SeriesScraper.Web/Pages/Notifications.razor
@@ -1,0 +1,105 @@
+@page "/notifications"
+@using SeriesScraper.Domain.Interfaces
+@inject IWatchlistNotificationService NotificationService
+
+<PageTitle>Notifications</PageTitle>
+
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h3>Notifications</h3>
+    @if (_notifications is not null && _notifications.Any(n => !n.IsRead))
+    {
+        <button class="btn btn-outline-secondary btn-sm" @onclick="MarkAllRead">
+            <span class="oi oi-check" aria-hidden="true"></span> Mark all as read
+        </button>
+    }
+</div>
+
+@if (_loading)
+{
+    <div class="d-flex justify-content-center my-4">
+        <div class="spinner-border" role="status">
+            <span class="visually-hidden">Loading...</span>
+        </div>
+    </div>
+}
+else if (_notifications is null || _notifications.Count == 0)
+{
+    <div class="alert alert-info">No notifications yet. Notifications appear when scrape runs find links matching your watchlist.</div>
+}
+else
+{
+    <div class="table-responsive">
+        <table class="table table-striped table-hover">
+            <thead class="table-dark">
+                <tr>
+                    <th>Title</th>
+                    <th>Link</th>
+                    <th>Found At</th>
+                    <th>Status</th>
+                    <th>Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var n in _notifications)
+                {
+                    <tr class="@(n.IsRead ? "text-muted" : "fw-bold")">
+                        <td>@n.WatchlistTitle</td>
+                        <td>
+                            <a href="@n.LinkUrl" target="_blank" rel="noopener noreferrer" class="text-truncate d-inline-block" style="max-width: 400px;">
+                                @n.LinkUrl
+                            </a>
+                        </td>
+                        <td>@n.CreatedAt.ToString("yyyy-MM-dd HH:mm")</td>
+                        <td>
+                            @if (n.IsRead)
+                            {
+                                <span class="badge bg-secondary">Read</span>
+                            }
+                            else
+                            {
+                                <span class="badge bg-primary">Unread</span>
+                            }
+                        </td>
+                        <td>
+                            @if (!n.IsRead)
+                            {
+                                <button class="btn btn-outline-primary btn-sm" @onclick="() => MarkRead(n.WatchlistNotificationId)">
+                                    Mark read
+                                </button>
+                            }
+                        </td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+}
+
+@code {
+    private IReadOnlyList<WatchlistNotificationDto>? _notifications;
+    private bool _loading = true;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadNotifications();
+    }
+
+    private async Task LoadNotifications()
+    {
+        _loading = true;
+        _notifications = await NotificationService.GetAllNotificationsAsync();
+        _loading = false;
+    }
+
+    private async Task MarkRead(int notificationId)
+    {
+        await NotificationService.MarkAsReadAsync(notificationId);
+        await LoadNotifications();
+    }
+
+    private async Task MarkAllRead()
+    {
+        await NotificationService.MarkAllAsReadAsync();
+        await LoadNotifications();
+    }
+}

--- a/src/SeriesScraper.Web/Program.cs
+++ b/src/SeriesScraper.Web/Program.cs
@@ -109,6 +109,10 @@ try
     // Watchlist service (#19)
     builder.Services.AddScoped<IWatchlistService, WatchlistService>();
 
+    // Watchlist notifications (#103)
+    builder.Services.AddScoped<IWatchlistNotificationService, WatchlistNotificationService>();
+    builder.Services.AddScoped<IWatchlistNotificationRepository, WatchlistNotificationRepository>();
+
     // History service (#33)
     builder.Services.AddScoped<IHistoryService, HistoryService>();
     builder.Services.AddScoped<IWatchlistRepository, WatchlistRepository>();

--- a/src/SeriesScraper.Web/Program.cs
+++ b/src/SeriesScraper.Web/Program.cs
@@ -112,6 +112,7 @@ try
     // Watchlist notifications (#103)
     builder.Services.AddScoped<IWatchlistNotificationService, WatchlistNotificationService>();
     builder.Services.AddScoped<IWatchlistNotificationRepository, WatchlistNotificationRepository>();
+    builder.Services.AddScoped<IDashboardService, DashboardService>();
 
     // History service (#33)
     builder.Services.AddScoped<IHistoryService, HistoryService>();

--- a/src/SeriesScraper.Web/Shared/NavMenu.razor
+++ b/src/SeriesScraper.Web/Shared/NavMenu.razor
@@ -1,4 +1,7 @@
-﻿<div class="top-row ps-3 navbar navbar-dark">
+﻿@using SeriesScraper.Domain.Interfaces
+@inject IWatchlistNotificationService NotificationService
+
+<div class="top-row ps-3 navbar navbar-dark">
     <div class="container-fluid">
         <a class="navbar-brand" href="">SeriesScraper.Web</a>
         <button title="Navigation menu" class="navbar-toggler" @onclick="ToggleNavMenu">
@@ -25,6 +28,15 @@
             </NavLink>
         </div>
         <div class="nav-item px-3">
+            <NavLink class="nav-link" href="notifications">
+                <span class="oi oi-bell" aria-hidden="true"></span> Notifications
+                @if (_unreadCount > 0)
+                {
+                    <span class="badge bg-danger ms-1">@_unreadCount</span>
+                }
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
             <NavLink class="nav-link" href="runs">
                 <span class="oi oi-timer" aria-hidden="true"></span> Run Progress
             </NavLink>
@@ -44,8 +56,26 @@
 
 @code {
     private bool collapseNavMenu = true;
+    private int _unreadCount;
 
     private string? NavMenuCssClass => collapseNavMenu ? "collapse" : null;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await RefreshUnreadCount();
+    }
+
+    private async Task RefreshUnreadCount()
+    {
+        try
+        {
+            _unreadCount = await NotificationService.GetUnreadCountAsync();
+        }
+        catch
+        {
+            _unreadCount = 0;
+        }
+    }
 
     private void ToggleNavMenu()
     {

--- a/tests/SeriesScraper.Application.Tests/Services/DashboardServiceTests.cs
+++ b/tests/SeriesScraper.Application.Tests/Services/DashboardServiceTests.cs
@@ -306,6 +306,71 @@ public class DashboardServiceTests
         result.Watchlist.TotalWatchlistItems.Should().Be(0);
     }
 
+    // ── UnreadNotificationCount ─────────────────────────────────────────
+
+    [Fact]
+    public void Constructor_NullNotificationRepository_Throws()
+    {
+        var act = () => new DashboardService(
+            _forumRepository,
+            _scrapeRunRepository,
+            _runProgressService,
+            _settingsService,
+            _watchlistService,
+            _statsProvider,
+            _importTrigger,
+            null!,
+            _logger);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("notificationRepository");
+    }
+
+    [Fact]
+    public async Task GetDashboardAsync_ReturnsUnreadNotificationCountFromRepository()
+    {
+        SetupEmptyDefaults();
+        _notificationRepository.GetUnreadCountAsync(Arg.Any<CancellationToken>()).Returns(7);
+
+        var result = await _sut.GetDashboardAsync();
+
+        result.UnreadNotificationCount.Should().Be(7);
+    }
+
+    [Fact]
+    public async Task GetDashboardAsync_ZeroUnread_ReturnsZero()
+    {
+        SetupEmptyDefaults();
+        _notificationRepository.GetUnreadCountAsync(Arg.Any<CancellationToken>()).Returns(0);
+
+        var result = await _sut.GetDashboardAsync();
+
+        result.UnreadNotificationCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GetDashboardAsync_PassesCancellationTokenToNotificationRepository()
+    {
+        using var cts = new CancellationTokenSource();
+        var token = cts.Token;
+        SetupEmptyDefaults();
+        _notificationRepository.GetUnreadCountAsync(Arg.Any<CancellationToken>()).Returns(3);
+
+        await _sut.GetDashboardAsync(token);
+
+        await _notificationRepository.Received(1).GetUnreadCountAsync(token);
+    }
+
+    [Fact]
+    public async Task GetDashboardAsync_ReturnsDashboardDto()
+    {
+        SetupEmptyDefaults();
+        _notificationRepository.GetUnreadCountAsync(Arg.Any<CancellationToken>()).Returns(5);
+
+        var result = await _sut.GetDashboardAsync();
+
+        result.Should().NotBeNull();
+        result.Should().BeOfType<DashboardDto>();
+    }
+
     // ── Helpers ─────────────────────────────────────────────────────────
 
     private void SetupEmptyDefaults()

--- a/tests/SeriesScraper.Application.Tests/Services/DashboardServiceTests.cs
+++ b/tests/SeriesScraper.Application.Tests/Services/DashboardServiceTests.cs
@@ -19,6 +19,7 @@ public class DashboardServiceTests
     private readonly IWatchlistService _watchlistService;
     private readonly IDatabaseStatsProvider _statsProvider;
     private readonly IImdbImportTrigger _importTrigger;
+    private readonly IWatchlistNotificationRepository _notificationRepository;
     private readonly ILogger<DashboardService> _logger;
     private readonly DashboardService _sut;
 
@@ -31,6 +32,7 @@ public class DashboardServiceTests
         _watchlistService = Substitute.For<IWatchlistService>();
         _statsProvider = Substitute.For<IDatabaseStatsProvider>();
         _importTrigger = Substitute.For<IImdbImportTrigger>();
+        _notificationRepository = Substitute.For<IWatchlistNotificationRepository>();
         _logger = Substitute.For<ILogger<DashboardService>>();
         _sut = new DashboardService(
             _forumRepository,
@@ -40,6 +42,7 @@ public class DashboardServiceTests
             _watchlistService,
             _statsProvider,
             _importTrigger,
+            _notificationRepository,
             _logger);
     }
 

--- a/tests/SeriesScraper.Application.Tests/Services/ScrapeOrchestratorTests.cs
+++ b/tests/SeriesScraper.Application.Tests/Services/ScrapeOrchestratorTests.cs
@@ -18,6 +18,7 @@ public class ScrapeOrchestratorTests
     private readonly IScrapeRunRepository _runRepository;
     private readonly ILinkRepository _linkRepository;
     private readonly IImdbMatchingService _matchingService;
+    private readonly IWatchlistNotificationService _notificationService;
     private readonly ILogger<ScrapeOrchestrator> _logger;
     private readonly ScrapeOrchestrator _sut;
 
@@ -39,6 +40,7 @@ public class ScrapeOrchestratorTests
         _runRepository = Substitute.For<IScrapeRunRepository>();
         _linkRepository = Substitute.For<ILinkRepository>();
         _matchingService = Substitute.For<IImdbMatchingService>();
+        _notificationService = Substitute.For<IWatchlistNotificationService>();
         _logger = Substitute.For<ILogger<ScrapeOrchestrator>>();
 
         _forumRepository.GetByIdAsync(1, Arg.Any<CancellationToken>())
@@ -46,7 +48,8 @@ public class ScrapeOrchestratorTests
 
         _sut = new ScrapeOrchestrator(
             _postScraper, _searchService, _forumRepository,
-            _runRepository, _linkRepository, _matchingService, _logger);
+            _runRepository, _linkRepository, _matchingService,
+            _notificationService, _logger);
     }
 
     private ScrapeJob CreateJob(int runId = 1, int forumId = 1,
@@ -71,7 +74,8 @@ public class ScrapeOrchestratorTests
     {
         var act = () => new ScrapeOrchestrator(
             null!, _searchService, _forumRepository,
-            _runRepository, _linkRepository, _matchingService, _logger);
+            _runRepository, _linkRepository, _matchingService,
+            _notificationService, _logger);
         act.Should().Throw<ArgumentNullException>().WithParameterName("postScraper");
     }
 
@@ -80,7 +84,8 @@ public class ScrapeOrchestratorTests
     {
         var act = () => new ScrapeOrchestrator(
             _postScraper, null!, _forumRepository,
-            _runRepository, _linkRepository, _matchingService, _logger);
+            _runRepository, _linkRepository, _matchingService,
+            _notificationService, _logger);
         act.Should().Throw<ArgumentNullException>().WithParameterName("searchService");
     }
 
@@ -89,7 +94,8 @@ public class ScrapeOrchestratorTests
     {
         var act = () => new ScrapeOrchestrator(
             _postScraper, _searchService, null!,
-            _runRepository, _linkRepository, _matchingService, _logger);
+            _runRepository, _linkRepository, _matchingService,
+            _notificationService, _logger);
         act.Should().Throw<ArgumentNullException>().WithParameterName("forumRepository");
     }
 
@@ -98,7 +104,8 @@ public class ScrapeOrchestratorTests
     {
         var act = () => new ScrapeOrchestrator(
             _postScraper, _searchService, _forumRepository,
-            null!, _linkRepository, _matchingService, _logger);
+            null!, _linkRepository, _matchingService,
+            _notificationService, _logger);
         act.Should().Throw<ArgumentNullException>().WithParameterName("runRepository");
     }
 
@@ -107,7 +114,8 @@ public class ScrapeOrchestratorTests
     {
         var act = () => new ScrapeOrchestrator(
             _postScraper, _searchService, _forumRepository,
-            _runRepository, null!, _matchingService, _logger);
+            _runRepository, null!, _matchingService,
+            _notificationService, _logger);
         act.Should().Throw<ArgumentNullException>().WithParameterName("linkRepository");
     }
 
@@ -116,7 +124,8 @@ public class ScrapeOrchestratorTests
     {
         var act = () => new ScrapeOrchestrator(
             _postScraper, _searchService, _forumRepository,
-            _runRepository, _linkRepository, null!, _logger);
+            _runRepository, _linkRepository, null!,
+            _notificationService, _logger);
         act.Should().Throw<ArgumentNullException>().WithParameterName("matchingService");
     }
 
@@ -125,7 +134,8 @@ public class ScrapeOrchestratorTests
     {
         var act = () => new ScrapeOrchestrator(
             _postScraper, _searchService, _forumRepository,
-            _runRepository, _linkRepository, _matchingService, null!);
+            _runRepository, _linkRepository, _matchingService,
+            _notificationService, null!);
         act.Should().Throw<ArgumentNullException>().WithParameterName("logger");
     }
 
@@ -575,5 +585,54 @@ public class ScrapeOrchestratorTests
         await _runRepository.Received(1).UpdateRunItemStatusAsync(
             Arg.Any<int>(), ScrapeRunItemStatus.Failed, Arg.Any<CancellationToken>());
         await _runRepository.Received(3).IncrementProcessedItemsAsync(1, Arg.Any<CancellationToken>());
+    }
+
+    // --- Watchlist Notification Integration ---
+
+    [Fact]
+    public async Task ExecuteAsync_CallsNotificationServiceAfterProcessing()
+    {
+        var urls = new[] { "https://forum.example.com/thread/1" };
+        var job = CreateJob(postUrls: urls);
+
+        _postScraper.ScrapePostAsync(Arg.Any<Forum>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(ci => PostScrapeResult.Succeeded(ci.ArgAt<string>(1), Array.Empty<Link>()));
+
+        _runRepository.GetByIdAsync(1, Arg.Any<CancellationToken>())
+            .Returns(new ScrapeRun { RunId = 1, ForumId = 1, Status = ScrapeRunStatus.Running });
+
+        await _sut.ExecuteAsync(job);
+
+        await _notificationService.Received(1).CreateNotificationsForRunAsync(1, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NotificationServiceFailure_DoesNotThrow()
+    {
+        var urls = new[] { "https://forum.example.com/thread/1" };
+        var job = CreateJob(postUrls: urls);
+
+        _postScraper.ScrapePostAsync(Arg.Any<Forum>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(ci => PostScrapeResult.Succeeded(ci.ArgAt<string>(1), Array.Empty<Link>()));
+
+        _runRepository.GetByIdAsync(1, Arg.Any<CancellationToken>())
+            .Returns(new ScrapeRun { RunId = 1, ForumId = 1, Status = ScrapeRunStatus.Running });
+
+        _notificationService.CreateNotificationsForRunAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException(new InvalidOperationException("DB error")));
+
+        // Should not throw — notification failure is non-fatal
+        var act = () => _sut.ExecuteAsync(job);
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public void Constructor_NullNotificationService_Throws()
+    {
+        var act = () => new ScrapeOrchestrator(
+            _postScraper, _searchService, _forumRepository,
+            _runRepository, _linkRepository, _matchingService,
+            null!, _logger);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("notificationService");
     }
 }

--- a/tests/SeriesScraper.Application.Tests/Services/ScrapeOrchestratorTests.cs
+++ b/tests/SeriesScraper.Application.Tests/Services/ScrapeOrchestratorTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using SeriesScraper.Application.Services;
+using SeriesScraper.Application.Utilities;
 using SeriesScraper.Domain.Entities;
 using SeriesScraper.Domain.Enums;
 using SeriesScraper.Domain.Interfaces;
@@ -533,7 +534,7 @@ public class ScrapeOrchestratorTests
     [InlineData("not-a-uri", null)]
     public void ExtractTitleFromUrl_VariousInputs_ReturnsExpected(string url, string? expected)
     {
-        var result = ScrapeOrchestrator.ExtractTitleFromUrl(url);
+        var result = UrlTitleExtractor.ExtractFrom(url);
         result.Should().Be(expected);
     }
 

--- a/tests/SeriesScraper.Application.Tests/Services/WatchlistNotificationServiceTests.cs
+++ b/tests/SeriesScraper.Application.Tests/Services/WatchlistNotificationServiceTests.cs
@@ -1,0 +1,358 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using SeriesScraper.Application.Services;
+using SeriesScraper.Domain.Entities;
+using SeriesScraper.Domain.Enums;
+using SeriesScraper.Domain.Interfaces;
+
+namespace SeriesScraper.Application.Tests.Services;
+
+public class WatchlistNotificationServiceTests
+{
+    private readonly IWatchlistNotificationRepository _notificationRepository;
+    private readonly IWatchlistRepository _watchlistRepository;
+    private readonly ILinkRepository _linkRepository;
+    private readonly ILogger<WatchlistNotificationService> _logger;
+    private readonly WatchlistNotificationService _sut;
+
+    public WatchlistNotificationServiceTests()
+    {
+        _notificationRepository = Substitute.For<IWatchlistNotificationRepository>();
+        _watchlistRepository = Substitute.For<IWatchlistRepository>();
+        _linkRepository = Substitute.For<ILinkRepository>();
+        _logger = Substitute.For<ILogger<WatchlistNotificationService>>();
+
+        _sut = new WatchlistNotificationService(
+            _notificationRepository,
+            _watchlistRepository,
+            _linkRepository,
+            _logger);
+    }
+
+    // ─── Constructor Validation ───────────────────────────────────
+
+    [Fact]
+    public void Constructor_NullNotificationRepository_Throws()
+    {
+        var act = () => new WatchlistNotificationService(null!, _watchlistRepository, _linkRepository, _logger);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("notificationRepository");
+    }
+
+    [Fact]
+    public void Constructor_NullWatchlistRepository_Throws()
+    {
+        var act = () => new WatchlistNotificationService(_notificationRepository, null!, _linkRepository, _logger);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("watchlistRepository");
+    }
+
+    [Fact]
+    public void Constructor_NullLinkRepository_Throws()
+    {
+        var act = () => new WatchlistNotificationService(_notificationRepository, _watchlistRepository, null!, _logger);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("linkRepository");
+    }
+
+    [Fact]
+    public void Constructor_NullLogger_Throws()
+    {
+        var act = () => new WatchlistNotificationService(_notificationRepository, _watchlistRepository, _linkRepository, null!);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("logger");
+    }
+
+    // ─── CreateNotificationsForRunAsync ───────────────────────────
+
+    [Fact]
+    public async Task CreateNotificationsForRunAsync_NoActiveWatchlistItems_SkipsProcessing()
+    {
+        _watchlistRepository.GetAllAsync(activeOnly: true, Arg.Any<CancellationToken>())
+            .Returns(new List<WatchlistItem>());
+
+        await _sut.CreateNotificationsForRunAsync(1);
+
+        await _linkRepository.DidNotReceive().GetCurrentByRunIdAsync(Arg.Any<int>(), Arg.Any<CancellationToken>());
+        await _notificationRepository.DidNotReceive().AddRangeAsync(Arg.Any<IEnumerable<WatchlistNotification>>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CreateNotificationsForRunAsync_NoLinks_SkipsProcessing()
+    {
+        _watchlistRepository.GetAllAsync(activeOnly: true, Arg.Any<CancellationToken>())
+            .Returns(new List<WatchlistItem>
+            {
+                new() { WatchlistItemId = 1, CustomTitle = "Test", MediaTitleId = 10, NotificationPreference = NotificationPreference.OnNewLinks, IsActive = true }
+            });
+        _linkRepository.GetCurrentByRunIdAsync(1, Arg.Any<CancellationToken>())
+            .Returns(new List<Link>());
+
+        await _sut.CreateNotificationsForRunAsync(1);
+
+        await _notificationRepository.DidNotReceive().AddRangeAsync(Arg.Any<IEnumerable<WatchlistNotification>>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CreateNotificationsForRunAsync_MatchingTitle_CreatesNotification()
+    {
+        var watchlistItem = new WatchlistItem
+        {
+            WatchlistItemId = 1,
+            CustomTitle = "Breaking Bad",
+            MediaTitleId = 10,
+            NotificationPreference = NotificationPreference.OnNewLinks,
+            IsActive = true
+        };
+
+        var link = new Link
+        {
+            LinkId = 100,
+            Url = "https://download.example.com/file.zip",
+            PostUrl = "https://forum.example.com/posts/breaking-bad-s01",
+            RunId = 1,
+            LinkTypeId = 1
+        };
+
+        _watchlistRepository.GetAllAsync(activeOnly: true, Arg.Any<CancellationToken>())
+            .Returns(new List<WatchlistItem> { watchlistItem });
+        _linkRepository.GetCurrentByRunIdAsync(1, Arg.Any<CancellationToken>())
+            .Returns(new List<Link> { link });
+
+        await _sut.CreateNotificationsForRunAsync(1);
+
+        await _notificationRepository.Received(1).AddRangeAsync(
+            Arg.Is<IEnumerable<WatchlistNotification>>(n => n.Count() == 1 &&
+                n.First().WatchlistItemId == 1 &&
+                n.First().LinkId == 100 &&
+                !n.First().IsRead),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CreateNotificationsForRunAsync_NonMatchingTitle_DoesNotCreateNotification()
+    {
+        var watchlistItem = new WatchlistItem
+        {
+            WatchlistItemId = 1,
+            CustomTitle = "Breaking Bad",
+            MediaTitleId = 10,
+            NotificationPreference = NotificationPreference.OnNewLinks,
+            IsActive = true
+        };
+
+        var link = new Link
+        {
+            LinkId = 100,
+            Url = "https://download.example.com/file.zip",
+            PostUrl = "https://forum.example.com/posts/game-of-thrones-s01",
+            RunId = 1,
+            LinkTypeId = 1
+        };
+
+        _watchlistRepository.GetAllAsync(activeOnly: true, Arg.Any<CancellationToken>())
+            .Returns(new List<WatchlistItem> { watchlistItem });
+        _linkRepository.GetCurrentByRunIdAsync(1, Arg.Any<CancellationToken>())
+            .Returns(new List<Link> { link });
+
+        await _sut.CreateNotificationsForRunAsync(1);
+
+        await _notificationRepository.DidNotReceive().AddRangeAsync(
+            Arg.Any<IEnumerable<WatchlistNotification>>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CreateNotificationsForRunAsync_NonePreference_SkipsItem()
+    {
+        var watchlistItem = new WatchlistItem
+        {
+            WatchlistItemId = 1,
+            CustomTitle = "Breaking Bad",
+            MediaTitleId = 10,
+            NotificationPreference = NotificationPreference.None,
+            IsActive = true
+        };
+
+        var link = new Link
+        {
+            LinkId = 100,
+            Url = "https://download.example.com/file.zip",
+            PostUrl = "https://forum.example.com/posts/breaking-bad-s01",
+            RunId = 1,
+            LinkTypeId = 1
+        };
+
+        _watchlistRepository.GetAllAsync(activeOnly: true, Arg.Any<CancellationToken>())
+            .Returns(new List<WatchlistItem> { watchlistItem });
+        _linkRepository.GetCurrentByRunIdAsync(1, Arg.Any<CancellationToken>())
+            .Returns(new List<Link> { link });
+
+        await _sut.CreateNotificationsForRunAsync(1);
+
+        await _notificationRepository.DidNotReceive().AddRangeAsync(
+            Arg.Any<IEnumerable<WatchlistNotification>>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CreateNotificationsForRunAsync_CustomTitleMatch_CreatesNotification()
+    {
+        var watchlistItem = new WatchlistItem
+        {
+            WatchlistItemId = 2,
+            CustomTitle = "Stranger Things",
+            MediaTitleId = null,
+            NotificationPreference = NotificationPreference.OnNewLinks,
+            IsActive = true
+        };
+
+        var link = new Link
+        {
+            LinkId = 200,
+            Url = "https://download.example.com/file2.zip",
+            PostUrl = "https://forum.example.com/posts/stranger-things-s04",
+            RunId = 1,
+            LinkTypeId = 1
+        };
+
+        _watchlistRepository.GetAllAsync(activeOnly: true, Arg.Any<CancellationToken>())
+            .Returns(new List<WatchlistItem> { watchlistItem });
+        _linkRepository.GetCurrentByRunIdAsync(1, Arg.Any<CancellationToken>())
+            .Returns(new List<Link> { link });
+
+        await _sut.CreateNotificationsForRunAsync(1);
+
+        await _notificationRepository.Received(1).AddRangeAsync(
+            Arg.Is<IEnumerable<WatchlistNotification>>(n => n.Count() == 1 &&
+                n.First().WatchlistItemId == 2 &&
+                n.First().LinkId == 200),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CreateNotificationsForRunAsync_DeduplicatesByWatchlistItemAndLink()
+    {
+        // Two watchlist items with same title but different IDs; both match same link
+        var items = new List<WatchlistItem>
+        {
+            new() { WatchlistItemId = 1, CustomTitle = "Breaking Bad", MediaTitleId = 10, NotificationPreference = NotificationPreference.OnNewLinks, IsActive = true },
+        };
+
+        // Two links with same PostUrl (both match)
+        var links = new List<Link>
+        {
+            new() { LinkId = 100, Url = "https://dl.example.com/a.zip", PostUrl = "https://forum.example.com/posts/breaking-bad-s01", RunId = 1, LinkTypeId = 1 },
+            new() { LinkId = 101, Url = "https://dl.example.com/b.zip", PostUrl = "https://forum.example.com/posts/breaking-bad-s02", RunId = 1, LinkTypeId = 1 },
+        };
+
+        _watchlistRepository.GetAllAsync(activeOnly: true, Arg.Any<CancellationToken>())
+            .Returns(items);
+        _linkRepository.GetCurrentByRunIdAsync(1, Arg.Any<CancellationToken>())
+            .Returns(links);
+
+        await _sut.CreateNotificationsForRunAsync(1);
+
+        await _notificationRepository.Received(1).AddRangeAsync(
+            Arg.Is<IEnumerable<WatchlistNotification>>(n => n.Count() == 2),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ─── GetAllNotificationsAsync ─────────────────────────────────
+
+    [Fact]
+    public async Task GetAllNotificationsAsync_ReturnsAllMappedDtos()
+    {
+        var notifications = new List<WatchlistNotification>
+        {
+            new()
+            {
+                WatchlistNotificationId = 1,
+                WatchlistItemId = 10,
+                LinkId = 100,
+                CreatedAt = new DateTime(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc),
+                IsRead = false,
+                WatchlistItem = new WatchlistItem { WatchlistItemId = 10, CustomTitle = "Breaking Bad" },
+                Link = new Link { LinkId = 100, Url = "https://dl.example.com/bb.zip", PostUrl = "https://forum.example.com/bb", LinkTypeId = 1, RunId = 1 }
+            },
+            new()
+            {
+                WatchlistNotificationId = 2,
+                WatchlistItemId = 20,
+                LinkId = 200,
+                CreatedAt = new DateTime(2026, 1, 2, 12, 0, 0, DateTimeKind.Utc),
+                IsRead = true,
+                WatchlistItem = new WatchlistItem { WatchlistItemId = 20, CustomTitle = "GoT" },
+                Link = new Link { LinkId = 200, Url = "https://dl.example.com/got.zip", PostUrl = "https://forum.example.com/got", LinkTypeId = 1, RunId = 1 }
+            }
+        };
+
+        _notificationRepository.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(notifications);
+
+        var result = await _sut.GetAllNotificationsAsync();
+
+        result.Should().HaveCount(2);
+        result[0].WatchlistNotificationId.Should().Be(1);
+        result[0].WatchlistTitle.Should().Be("Breaking Bad");
+        result[0].LinkUrl.Should().Be("https://dl.example.com/bb.zip");
+        result[0].IsRead.Should().BeFalse();
+        result[1].IsRead.Should().BeTrue();
+    }
+
+    // ─── GetUnreadNotificationsAsync ──────────────────────────────
+
+    [Fact]
+    public async Task GetUnreadNotificationsAsync_ReturnsOnlyUnread()
+    {
+        var notifications = new List<WatchlistNotification>
+        {
+            new()
+            {
+                WatchlistNotificationId = 1,
+                WatchlistItemId = 10,
+                LinkId = 100,
+                CreatedAt = DateTime.UtcNow,
+                IsRead = false,
+                WatchlistItem = new WatchlistItem { WatchlistItemId = 10, CustomTitle = "Test" },
+                Link = new Link { LinkId = 100, Url = "https://dl.example.com/a.zip", PostUrl = "https://forum.example.com/a", LinkTypeId = 1, RunId = 1 }
+            }
+        };
+
+        _notificationRepository.GetUnreadAsync(Arg.Any<CancellationToken>())
+            .Returns(notifications);
+
+        var result = await _sut.GetUnreadNotificationsAsync();
+
+        result.Should().HaveCount(1);
+        result[0].IsRead.Should().BeFalse();
+    }
+
+    // ─── GetUnreadCountAsync ──────────────────────────────────────
+
+    [Fact]
+    public async Task GetUnreadCountAsync_ReturnsCount()
+    {
+        _notificationRepository.GetUnreadCountAsync(Arg.Any<CancellationToken>())
+            .Returns(5);
+
+        var result = await _sut.GetUnreadCountAsync();
+
+        result.Should().Be(5);
+    }
+
+    // ─── MarkAsReadAsync ──────────────────────────────────────────
+
+    [Fact]
+    public async Task MarkAsReadAsync_DelegatesToRepository()
+    {
+        await _sut.MarkAsReadAsync(42);
+
+        await _notificationRepository.Received(1).MarkAsReadAsync(42, Arg.Any<CancellationToken>());
+    }
+
+    // ─── MarkAllAsReadAsync ───────────────────────────────────────
+
+    [Fact]
+    public async Task MarkAllAsReadAsync_DelegatesToRepository()
+    {
+        await _sut.MarkAllAsReadAsync();
+
+        await _notificationRepository.Received(1).MarkAllAsReadAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/SeriesScraper.Domain.Tests/Entities/WatchlistNotificationTests.cs
+++ b/tests/SeriesScraper.Domain.Tests/Entities/WatchlistNotificationTests.cs
@@ -1,0 +1,70 @@
+using FluentAssertions;
+using SeriesScraper.Domain.Entities;
+
+namespace SeriesScraper.Domain.Tests.Entities;
+
+public class WatchlistNotificationTests
+{
+    [Fact]
+    public void WatchlistNotification_DefaultIsRead_IsFalse()
+    {
+        var notification = new WatchlistNotification();
+
+        notification.IsRead.Should().BeFalse();
+    }
+
+    [Fact]
+    public void WatchlistNotification_CanSetProperties()
+    {
+        var notification = new WatchlistNotification
+        {
+            WatchlistNotificationId = 1,
+            WatchlistItemId = 10,
+            LinkId = 100,
+            CreatedAt = new DateTime(2026, 4, 3, 12, 0, 0, DateTimeKind.Utc),
+            IsRead = true
+        };
+
+        notification.WatchlistNotificationId.Should().Be(1);
+        notification.WatchlistItemId.Should().Be(10);
+        notification.LinkId.Should().Be(100);
+        notification.CreatedAt.Should().Be(new DateTime(2026, 4, 3, 12, 0, 0, DateTimeKind.Utc));
+        notification.IsRead.Should().BeTrue();
+    }
+
+    [Fact]
+    public void WatchlistNotification_NavigationProperties_DefaultToNull()
+    {
+        var notification = new WatchlistNotification();
+
+        // Navigation properties are initialized to null! via default
+        // but the default value for reference type fields when not set is null
+        notification.WatchlistItemId.Should().Be(0);
+        notification.LinkId.Should().Be(0);
+    }
+
+    [Fact]
+    public void WatchlistNotification_CanSetNavigationProperties()
+    {
+        var watchlistItem = new WatchlistItem { WatchlistItemId = 10, CustomTitle = "Test" };
+        var link = new Link
+        {
+            LinkId = 100,
+            Url = "https://example.com/file.zip",
+            PostUrl = "https://forum.example.com/post/1",
+            LinkTypeId = 1,
+            RunId = 1
+        };
+
+        var notification = new WatchlistNotification
+        {
+            WatchlistItemId = 10,
+            LinkId = 100,
+            WatchlistItem = watchlistItem,
+            Link = link
+        };
+
+        notification.WatchlistItem.Should().BeSameAs(watchlistItem);
+        notification.Link.Should().BeSameAs(link);
+    }
+}

--- a/tests/SeriesScraper.Web.Tests/Pages/NotificationsTests.cs
+++ b/tests/SeriesScraper.Web.Tests/Pages/NotificationsTests.cs
@@ -1,0 +1,188 @@
+using Bunit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using SeriesScraper.Domain.Interfaces;
+using SeriesScraper.Web.Pages;
+
+namespace SeriesScraper.Web.Tests.Pages;
+
+public class NotificationsTests : TestContext
+{
+    private readonly IWatchlistNotificationService _service;
+
+    public NotificationsTests()
+    {
+        _service = Substitute.For<IWatchlistNotificationService>();
+        Services.AddSingleton(_service);
+    }
+
+    // ─── Loading state ────────────────────────────────────────────
+
+    [Fact]
+    public async Task Notifications_EmptyList_ShowsNoNotificationsMessage()
+    {
+        _service.GetAllNotificationsAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<WatchlistNotificationDto>());
+
+        var cut = RenderComponent<Notifications>();
+        await cut.InvokeAsync(() => Task.CompletedTask); // wait for lifecycle
+
+        cut.Markup.Should().Contain("No notifications yet");
+    }
+
+    // ─── Displays correct data ────────────────────────────────────
+
+    [Fact]
+    public async Task Notifications_WithItems_ShowsTitleLanguageQualityLinkAndTime()
+    {
+        var notifications = new List<WatchlistNotificationDto>
+        {
+            new()
+            {
+                WatchlistNotificationId = 1,
+                WatchlistItemId = 10,
+                WatchlistTitle = "Breaking Bad",
+                LinkId = 100,
+                LinkUrl = "https://example.com/download/bb.torrent",
+                Language = "en",
+                Quality = "1080p BluRay",
+                CreatedAt = new DateTime(2026, 4, 1, 12, 0, 0, DateTimeKind.Utc),
+                IsRead = false
+            }
+        };
+
+        _service.GetAllNotificationsAsync(Arg.Any<CancellationToken>())
+            .Returns(notifications);
+
+        var cut = RenderComponent<Notifications>();
+        await cut.InvokeAsync(() => Task.CompletedTask);
+
+        cut.Markup.Should().Contain("Breaking Bad");
+        cut.Markup.Should().Contain("en");
+        cut.Markup.Should().Contain("1080p BluRay");
+        cut.Markup.Should().Contain("https://example.com/download/bb.torrent");
+        cut.Markup.Should().Contain("2026-04-01");
+    }
+
+    [Fact]
+    public async Task Notifications_NullLanguageAndQuality_ShowsDash()
+    {
+        var notifications = new List<WatchlistNotificationDto>
+        {
+            new()
+            {
+                WatchlistNotificationId = 2,
+                WatchlistItemId = 10,
+                WatchlistTitle = "Test Show",
+                LinkId = 101,
+                LinkUrl = "https://example.com/file.zip",
+                Language = null,
+                Quality = null,
+                CreatedAt = DateTime.UtcNow,
+                IsRead = false
+            }
+        };
+
+        _service.GetAllNotificationsAsync(Arg.Any<CancellationToken>())
+            .Returns(notifications);
+
+        var cut = RenderComponent<Notifications>();
+        await cut.InvokeAsync(() => Task.CompletedTask);
+
+        // null Language and Quality show as "—"
+        cut.FindAll("td").Select(td => td.TextContent)
+            .Count(t => t == "—").Should().BeGreaterThanOrEqualTo(2);
+    }
+
+    // ─── Mark read ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Notifications_MarkReadButton_CallsMarkAsReadAndReloads()
+    {
+        var notifications = new List<WatchlistNotificationDto>
+        {
+            new()
+            {
+                WatchlistNotificationId = 5,
+                WatchlistItemId = 1,
+                WatchlistTitle = "Show",
+                LinkId = 1,
+                LinkUrl = "https://example.com",
+                CreatedAt = DateTime.UtcNow,
+                IsRead = false
+            }
+        };
+
+        _service.GetAllNotificationsAsync(Arg.Any<CancellationToken>())
+            .Returns(notifications, new List<WatchlistNotificationDto>());
+
+        var cut = RenderComponent<Notifications>();
+        await cut.InvokeAsync(() => Task.CompletedTask);
+
+        var markReadButton = cut.Find("button.btn-outline-primary");
+        await cut.InvokeAsync(() => markReadButton.Click());
+
+        await _service.Received(1).MarkAsReadAsync(5, Arg.Any<CancellationToken>());
+        // After reload the list is empty, showing the empty message
+        cut.Markup.Should().Contain("No notifications yet");
+    }
+
+    // ─── Mark all read ────────────────────────────────────────────
+
+    [Fact]
+    public async Task Notifications_MarkAllReadButton_CallsMarkAllAsReadAndReloads()
+    {
+        var notifications = new List<WatchlistNotificationDto>
+        {
+            new()
+            {
+                WatchlistNotificationId = 3,
+                WatchlistItemId = 1,
+                WatchlistTitle = "Show",
+                LinkId = 1,
+                LinkUrl = "https://example.com",
+                CreatedAt = DateTime.UtcNow,
+                IsRead = false
+            }
+        };
+
+        _service.GetAllNotificationsAsync(Arg.Any<CancellationToken>())
+            .Returns(notifications, new List<WatchlistNotificationDto>());
+
+        var cut = RenderComponent<Notifications>();
+        await cut.InvokeAsync(() => Task.CompletedTask);
+
+        var markAllButton = cut.Find("button.btn-outline-secondary");
+        await cut.InvokeAsync(() => markAllButton.Click());
+
+        await _service.Received(1).MarkAllAsReadAsync(Arg.Any<CancellationToken>());
+        cut.Markup.Should().Contain("No notifications yet");
+    }
+
+    [Fact]
+    public async Task Notifications_AllRead_DoesNotShowMarkAllReadButton()
+    {
+        var notifications = new List<WatchlistNotificationDto>
+        {
+            new()
+            {
+                WatchlistNotificationId = 4,
+                WatchlistItemId = 1,
+                WatchlistTitle = "Show",
+                LinkId = 1,
+                LinkUrl = "https://example.com",
+                CreatedAt = DateTime.UtcNow,
+                IsRead = true
+            }
+        };
+
+        _service.GetAllNotificationsAsync(Arg.Any<CancellationToken>())
+            .Returns(notifications);
+
+        var cut = RenderComponent<Notifications>();
+        await cut.InvokeAsync(() => Task.CompletedTask);
+
+        cut.FindAll("button.btn-outline-secondary").Should().BeEmpty();
+    }
+}

--- a/tests/SeriesScraper.Web.Tests/SeriesScraper.Web.Tests.csproj
+++ b/tests/SeriesScraper.Web.Tests/SeriesScraper.Web.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="bunit" Version="1.28.9" />
+    <PackageReference Include="bunit" Version="1.24.10" />
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
     <PackageReference Include="FluentAssertions" Version="6.12.*" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.*" />

--- a/tests/SeriesScraper.Web.Tests/Shared/NavMenuTests.cs
+++ b/tests/SeriesScraper.Web.Tests/Shared/NavMenuTests.cs
@@ -1,0 +1,73 @@
+using Bunit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using SeriesScraper.Domain.Interfaces;
+using SeriesScraper.Web.Shared;
+
+namespace SeriesScraper.Web.Tests.Shared;
+
+public class NavMenuTests : TestContext
+{
+    private readonly IWatchlistNotificationService _service;
+
+    public NavMenuTests()
+    {
+        _service = Substitute.For<IWatchlistNotificationService>();
+        Services.AddSingleton(_service);
+    }
+
+    // ─── Badge visibility ─────────────────────────────────────────
+
+    [Fact]
+    public async Task NavMenu_UnreadCountGreaterThanZero_ShowsBadgeWithCount()
+    {
+        _service.GetUnreadCountAsync(Arg.Any<CancellationToken>())
+            .Returns(3);
+
+        var cut = RenderComponent<NavMenu>();
+        await cut.InvokeAsync(() => Task.CompletedTask);
+
+        var badge = cut.Find("span.badge.bg-danger");
+        badge.Should().NotBeNull();
+        badge.TextContent.Trim().Should().Be("3");
+    }
+
+    [Fact]
+    public async Task NavMenu_UnreadCountZero_HidesBadge()
+    {
+        _service.GetUnreadCountAsync(Arg.Any<CancellationToken>())
+            .Returns(0);
+
+        var cut = RenderComponent<NavMenu>();
+        await cut.InvokeAsync(() => Task.CompletedTask);
+
+        cut.FindAll("span.badge.bg-danger").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task NavMenu_ServiceThrows_DefaultsToZeroAndHidesBadge()
+    {
+        _service.GetUnreadCountAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<int>(new InvalidOperationException("DB unavailable")));
+
+        var cut = RenderComponent<NavMenu>();
+        await cut.InvokeAsync(() => Task.CompletedTask);
+
+        cut.FindAll("span.badge.bg-danger").Should().BeEmpty();
+    }
+
+    // ─── Navigation links ─────────────────────────────────────────
+
+    [Fact]
+    public async Task NavMenu_Always_ContainsNotificationsLink()
+    {
+        _service.GetUnreadCountAsync(Arg.Any<CancellationToken>())
+            .Returns(0);
+
+        var cut = RenderComponent<NavMenu>();
+        await cut.InvokeAsync(() => Task.CompletedTask);
+
+        cut.Markup.Should().Contain("href=\"notifications\"");
+    }
+}


### PR DESCRIPTION
Closes #103

## Summary of Changes

When a scrape run completes, the ScrapeOrchestrator now cross-checks new links against active watchlist items and creates WatchlistNotification records for matches. Notifications are surfaced via a bell icon badge in the nav bar and a dedicated /notifications page.

### New files
- **Domain**: WatchlistNotification entity, IWatchlistNotificationRepository, IWatchlistNotificationService + DTOs
- **Application**: WatchlistNotificationService — creates notifications after scrape runs, manages read/unread state
- **Infrastructure**: WatchlistNotificationConfiguration (EF Core Fluent API), WatchlistNotificationRepository, migration
- **Web**: /notifications page (list, mark-read, mark-all-read), NavMenu bell icon with unread badge

### Modified files
- ScrapeOrchestrator — added IWatchlistNotificationService dependency, calls CreateNotificationsForRunAsync after processing
- AppDbContext — added WatchlistNotifications DbSet
- Program.cs — registered notification service + repository in DI
- NavMenu.razor — bell icon with unread badge count
- ScrapeOrchestratorTests — updated constructor calls for new dependency, added integration tests

### Testing notes
- 19 new tests added (4 entity, 12 service, 3 orchestrator integration)
- All 526 tests pass
- Notification creation failure is non-fatal (try/catch in orchestrator)
- Matching: title substring matching (case-insensitive) via URL-extracted titles
- Deduplication: unique constraint on (WatchlistItemId, LinkId); in-memory dedup before insert

### Known limitations
- Matching is based on title extraction from post URLs (same as IMDB matching) — not foolproof for all URL formats
- Dashboard widget not added (Index.razor redirects to /results) — can be added as follow-up
